### PR TITLE
Expose configurable launcher update server

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,7 +1,9 @@
+export const DEFAULT_LAUNCHER_UPDATE_URL = 'http://centurionpvp.com/downloads/';
+
 export const FileMap: Record<
-	string,
-	{
-		extractPath: string;
+        string,
+        {
+                extractPath: string;
 		plus?: true;
 		optional?: true;
 		label?: string;

--- a/src/common/schemas.ts
+++ b/src/common/schemas.ts
@@ -1,12 +1,22 @@
 import { z } from 'zod';
 
+import { DEFAULT_LAUNCHER_UPDATE_URL } from './constants';
+
 /**
  * Zod type wrappers for use with form inputs
  */
+const protocolRegex = /^[a-zA-Z][a-zA-Z\d+\-.]*:\/\//;
+
+const normalizeLauncherUrl = (value: string) => {
+        const trimmed = value.trim();
+        const withProtocol = protocolRegex.test(trimmed) ? trimmed : `http://${trimmed}`;
+        return withProtocol.endsWith('/') ? withProtocol : `${withProtocol}/`;
+};
+
 const f = {
-	boolean: (defaultValue?: boolean) =>
-		z.boolean().nullish().default(!!defaultValue),
-	number: (defaultValue?: number, val?: (v: z.ZodNumber) => z.ZodNumber) =>
+        boolean: (defaultValue?: boolean) =>
+                z.boolean().nullish().default(!!defaultValue),
+        number: (defaultValue?: number, val?: (v: z.ZodNumber) => z.ZodNumber) =>
 		z.preprocess(
 			v =>
 				v === '' || v === undefined
@@ -19,14 +29,20 @@ const f = {
 };
 
 export const PreferencesSchema = z.object({
-	isPortable: z.boolean().optional(),
-	clientDir: z.string().optional(),
-	reopenLauncher: f.boolean(),
-	cleanWdb: f.boolean(true),
-	rememberPosition: f.boolean(),
-	windowPosition: z
-		.object({
-			x: z.number(),
+        isPortable: z.boolean().optional(),
+        clientDir: z.string().optional(),
+        reopenLauncher: f.boolean(),
+        cleanWdb: f.boolean(true),
+        rememberPosition: f.boolean(),
+        launcherUpdateUrl: z
+                .string()
+                .trim()
+                .min(1)
+                .transform(normalizeLauncherUrl)
+                .default(DEFAULT_LAUNCHER_UPDATE_URL),
+        windowPosition: z
+                .object({
+                        x: z.number(),
 			y: z.number(),
 			width: z.number(),
 			height: z.number()

--- a/src/main/api/routers/preferences.ts
+++ b/src/main/api/routers/preferences.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 import { PreferencesSchema } from '~common/schemas';
 import Preferences from '~main/modules/preferences';
+import Updater from '~main/modules/updater';
 
 import { createTRPCRouter, publicProcedure } from '../trpc';
 
@@ -16,9 +17,18 @@ export const preferencesRouter = createTRPCRouter({
 			) {
 				throw new Error('Invalid client directory. WoW.exe not found.');
 			}
-			Preferences.data = input;
-			return Preferences.data;
-		}),
+                        const previousUrl = Preferences.data.launcherUpdateUrl;
+                        Preferences.data = input;
+
+                        if (
+                                input.launcherUpdateUrl !== undefined &&
+                                Preferences.data.launcherUpdateUrl !== previousUrl
+                        ) {
+                                void Updater.verify();
+                        }
+
+                        return Preferences.data;
+                }),
 	isValidClientDir: publicProcedure
 		.input(z.string().optional())
 		.query(({ input }) => Preferences.isValidClientDir(input))

--- a/src/main/modules/preferences.ts
+++ b/src/main/modules/preferences.ts
@@ -4,13 +4,16 @@ import fs from 'fs-extra';
 import { type z } from 'zod';
 import { app } from 'electron';
 
+import { DEFAULT_LAUNCHER_UPDATE_URL } from '~common/constants';
 import { PreferencesSchema } from '~common/schemas';
 import { omit } from '~common/utils';
 
 const portableDir = process.env.PORTABLE_EXECUTABLE_DIR;
 
 abstract class Preferences {
-	static #data: z.infer<typeof PreferencesSchema>;
+        static #data: z.infer<typeof PreferencesSchema> = PreferencesSchema.parse({
+                launcherUpdateUrl: DEFAULT_LAUNCHER_UPDATE_URL
+        });
 
 	static readonly userDataDir = process.env.PORTABLE_EXECUTABLE_DIR
 		? path.join(process.env.PORTABLE_EXECUTABLE_DIR, '.launcher')
@@ -38,11 +41,11 @@ abstract class Preferences {
 	}
 
 	static set data(newData: Partial<Omit<PreferencesSchema, 'portableDir'>>) {
-		this.#data = { ...this.#data, ...newData };
-		fs.writeJSON(
-			path.join(this.userDataDir, 'settings.json'),
-			omit(
-				this.#data,
+                this.#data = PreferencesSchema.parse({ ...this.#data, ...newData });
+                void fs.writeJSON(
+                        path.join(this.userDataDir, 'settings.json'),
+                        omit(
+                                this.#data,
 				portableDir ? ['isPortable', 'clientDir'] : ['isPortable']
 			),
 			{ spaces: 2 }

--- a/src/main/modules/updater.ts
+++ b/src/main/modules/updater.ts
@@ -11,7 +11,7 @@ import logger from 'electron-log';
 
 import { mainWindow } from '~main/index';
 import { formatDuration, formatFileSize } from '~common/utils';
-import { FileMap } from '~common/constants';
+import { DEFAULT_LAUNCHER_UPDATE_URL, FileMap } from '~common/constants';
 
 import Logger from './logger';
 import Preferences from './preferences';
@@ -23,7 +23,21 @@ autoUpdater.logger = logger;
 autoUpdater.autoDownload = false;
 autoUpdater.disableWebInstaller = true;
 
-const ServerUrl = 'http://centurionpvp.com/downloads/';
+const resolveBaseUrl = () => {
+        const { launcherUpdateUrl } = Preferences.data;
+        return launcherUpdateUrl ?? DEFAULT_LAUNCHER_UPDATE_URL;
+};
+
+const resolvePatchUrl = (filePath: string) =>
+        new URL(`patches/${filePath.replace(/^\/+/, '')}`, resolveBaseUrl()).toString();
+
+const configureAutoUpdaterFeed = () => {
+        try {
+                autoUpdater.setFeedURL({ url: new URL('patches/', resolveBaseUrl()).toString() });
+        } catch (e) {
+                Logger.log('Failed to configure launcher update feed URL', 'error', e);
+        }
+};
 
 // const isReadOnly = async (filePath: string) => {
 // 	try {
@@ -80,11 +94,11 @@ const fetchFile = async (
 			'downloads',
 			filePath
 		);
-		await resumableFetch(
-			`${ServerUrl}patches/${filePath}`,
-			downloadPath,
-			progressCb,
-			{
+                await resumableFetch(
+                        resolvePatchUrl(filePath),
+                        downloadPath,
+                        progressCb,
+                        {
 				throttle: 500
 			}
 		);
@@ -97,9 +111,9 @@ const fetchFile = async (
 
 const fetchSize = async (filePath: string) => {
 	try {
-		const response = await fetch(`${ServerUrl}patches/${filePath}`, {
-			method: 'HEAD'
-		});
+                const response = await fetch(resolvePatchUrl(filePath), {
+                        method: 'HEAD'
+                });
 		return parseInt(response.headers.get('content-length') ?? '0');
 	} catch (e) {
 		Logger.log(`Failed to download ${filePath}`, 'error', e);
@@ -109,7 +123,7 @@ const fetchSize = async (filePath: string) => {
 
 const fetchVersion = async (filePath: string) => {
 	try {
-		const response = await fetch(`${ServerUrl}patches/${filePath}`);
+                const response = await fetch(resolvePatchUrl(filePath));
 		return response.text();
 	} catch (e) {
 		Logger.log(`Failed to download ${filePath}`, 'error', e);
@@ -237,10 +251,11 @@ class UpdaterClass extends Observable<UpdaterStatus> {
 			});
 			child.unref();
 			app.quit();
-		} else {
-			autoUpdater.on(
-				'download-progress',
-				({ percent, bytesPerSecond, total, transferred }) => {
+                } else {
+                        configureAutoUpdaterFeed();
+                        autoUpdater.on(
+                                'download-progress',
+                                ({ percent, bytesPerSecond, total, transferred }) => {
 					const eta = formatDuration((total - transferred) / bytesPerSecond);
 					this.status = {
 						state: 'updating',
@@ -280,10 +295,11 @@ class UpdaterClass extends Observable<UpdaterStatus> {
 					return;
 				}
 			} else {
-				try {
-					const update = await autoUpdater.checkForUpdates();
-					if (update) {
-						this.status = { state: 'launcherOutdated' };
+                                try {
+                                        configureAutoUpdaterFeed();
+                                        const update = await autoUpdater.checkForUpdates();
+                                        if (update) {
+                                                this.status = { state: 'launcherOutdated' };
 						return;
 					}
 				} catch (e) {

--- a/src/renderer/components/PreferencesDialog.tsx
+++ b/src/renderer/components/PreferencesDialog.tsx
@@ -1,6 +1,8 @@
 import { Download, FolderPen } from 'lucide-react';
+import { useEffect, useState } from 'react';
 
 import { api } from '~renderer/utils/api';
+import { DEFAULT_LAUNCHER_UPDATE_URL } from '~common/constants';
 
 import TextButton from './styled/TextButton';
 import CheckboxInput from './form/CheckboxInput';
@@ -11,10 +13,37 @@ import CloseButton from './styled/CloseButton';
 type Props = { close: () => void };
 
 const PreferencesDialog = ({ close }: Props) => {
-	const { data: pref } = api.preferences.get.useQuery();
-	const setPref = api.preferences.set.useMutation();
+        const { data: pref } = api.preferences.get.useQuery();
+        const setPref = api.preferences.set.useMutation();
 
-	const update = api.updater.update.useMutation();
+        const update = api.updater.update.useMutation();
+
+        const [launcherUpdateUrl, setLauncherUpdateUrl] = useState('');
+
+        useEffect(() => {
+                setLauncherUpdateUrl(pref?.launcherUpdateUrl ?? DEFAULT_LAUNCHER_UPDATE_URL);
+        }, [pref?.launcherUpdateUrl]);
+
+        const persistLauncherUpdateUrl = async () => {
+                const trimmed = launcherUpdateUrl.trim();
+                if (!pref) return;
+                if (!trimmed) {
+                        setLauncherUpdateUrl(pref.launcherUpdateUrl);
+                        return;
+                }
+
+                if (trimmed === pref.launcherUpdateUrl) return;
+
+                try {
+                        const updated = await setPref.mutateAsync({
+                                launcherUpdateUrl: trimmed
+                        });
+                        setLauncherUpdateUrl(updated.launcherUpdateUrl);
+                } catch (error) {
+                        setLauncherUpdateUrl(pref.launcherUpdateUrl);
+                        console.error(error);
+                }
+        };
 
 	return (
 		<div className="dialog">
@@ -56,16 +85,43 @@ const PreferencesDialog = ({ close }: Props) => {
 					setValue={v => setPref.mutateAsync({ reopenLauncher: v })}
 					label="Reopen launcher after WoW closes"
 				/>
-				<CheckboxInput
-					value={pref?.rememberPosition ?? false}
-					setValue={v => setPref.mutateAsync({ rememberPosition: v })}
-					label="Remember position & size of launcher window"
-				/>
-				<TextButton
-					icon={Download}
-					onClick={() => {
-						close();
-						update.mutateAsync(true);
+                                <CheckboxInput
+                                        value={pref?.rememberPosition ?? false}
+                                        setValue={v => setPref.mutateAsync({ rememberPosition: v })}
+                                        label="Remember position & size of launcher window"
+                                />
+                                <div className="mt-3 flex flex-col gap-1 pl-2">
+                                        <label
+                                                htmlFor="launcher-update-url"
+                                                className="text-sm text-text"
+                                        >
+                                                Launcher update server
+                                        </label>
+                                        <input
+                                                id="launcher-update-url"
+                                                className="rounded border border-text bg-transparent p-2 text-sm text-text focus:border-primary focus:outline-none"
+                                                value={launcherUpdateUrl}
+                                                onChange={event =>
+                                                        setLauncherUpdateUrl(event.target.value)
+                                                }
+                                                onBlur={persistLauncherUpdateUrl}
+                                                onKeyDown={event => {
+                                                        if (event.key === 'Enter') {
+                                                                event.preventDefault();
+                                                                event.currentTarget.blur();
+                                                        }
+                                                }}
+                                                placeholder={DEFAULT_LAUNCHER_UPDATE_URL}
+                                        />
+                                        <span className="text-xs text-textDark">
+                                                Changing this will automatically recheck for launcher updates.
+                                        </span>
+                                </div>
+                                <TextButton
+                                        icon={Download}
+                                        onClick={() => {
+                                                close();
+                                                update.mutateAsync(true);
 					}}
 				>
 					Force update


### PR DESCRIPTION
## Summary
- add a configurable launcher update server field to the shared preferences schema with sensible defaults
- persist the preference in settings.json, trigger launcher update verification when it changes, and update the UI to edit it
- respect the configured server when downloading patches and checking for launcher updates

## Testing
- npm run build:test

------
https://chatgpt.com/codex/tasks/task_e_68dd2acb68b883279b8ac06d776e5820