### PR TITLE
Remove NSIS installer from Windows build

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,5 @@ $ npm run dev
 ```bash
 $ npm run dist
 ```
+
+> The Windows build now produces only the portable executable (no installer).

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -16,12 +16,6 @@ win:
   artifactName: ${productName}.${ext}
   target:
     - portable
-    - nsis
-nsis:
-  artifactName: ${productName}_Installer.${ext}
-  uninstallDisplayName: ${productName}
-  oneClick: false
-  removeDefaultUninstallWelcomePage: true
 publish:
   - provider: generic
     url: 'http://centurionpvp.com/downloads/patches/'


### PR DESCRIPTION
## Summary
- update the electron-builder configuration to stop generating the NSIS installer
- clarify in the README that the Windows distribution is now the portable executable only

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd34459d2083278c67a4f81b527711