### PR TITLE
Add configurable realmlist preference

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,4 +1,5 @@
 export const DEFAULT_LAUNCHER_UPDATE_URL = 'http://centurionpvp.com/downloads/';
+export const DEFAULT_REALMLIST = 'centurionpvp.com';
 
 export const FileMap: Record<
         string,

--- a/src/common/schemas.ts
+++ b/src/common/schemas.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-import { DEFAULT_LAUNCHER_UPDATE_URL } from './constants';
+import { DEFAULT_LAUNCHER_UPDATE_URL, DEFAULT_REALMLIST } from './constants';
 
 /**
  * Zod type wrappers for use with form inputs
@@ -40,6 +40,7 @@ export const PreferencesSchema = z.object({
                 .min(1)
                 .transform(normalizeLauncherUrl)
                 .default(DEFAULT_LAUNCHER_UPDATE_URL),
+        realmList: z.string().trim().min(1).default(DEFAULT_REALMLIST),
         windowPosition: z
                 .object({
                         x: z.number(),

--- a/src/main/modules/patcher.ts
+++ b/src/main/modules/patcher.ts
@@ -6,10 +6,11 @@ import fs from 'fs-extra';
 import Preferences from '~main/modules/preferences';
 import { isNotUndef } from '~common/utils';
 import Logger from '~main/modules/logger';
+import { DEFAULT_REALMLIST } from '~common/constants';
 
 export const patchConfig = async () => {
-	const { clientDir, plusEnabled } = Preferences.data;
-	if (!clientDir) return;
+        const { clientDir, plusEnabled, realmList } = Preferences.data;
+        if (!clientDir) return;
 
 	// Patch WoW.exe
 	const exePath = path.join(clientDir, 'WoW.exe');
@@ -61,17 +62,19 @@ export const patchConfig = async () => {
 	const primaryDisplay = screen.getPrimaryDisplay();
 	const { width, height } = primaryDisplay.bounds;
 
-	const realmInfo = plusEnabled
-		? {
-				realmList: 'centurionpvp.com',
-				patchList: 'centurionpvp.com',
-				realmName: 'Legionnaire Plus'
-		  }
-		: {
-				realmList: 'centurionpvp.com',
-				patchList: 'centurionpvp.com',
-				realmName: 'Legionnaire'
-		  };
+        const realmHost = realmList ?? DEFAULT_REALMLIST;
+
+        const realmInfo = plusEnabled
+                ? {
+                                realmList: realmHost,
+                                patchList: realmHost,
+                                realmName: 'Legionnaire Plus'
+                  }
+                : {
+                                realmList: realmHost,
+                                patchList: realmHost,
+                                realmName: 'Legionnaire'
+                  };
 
 	const parsed = {
 		// Defaults

--- a/src/main/modules/preferences.ts
+++ b/src/main/modules/preferences.ts
@@ -4,7 +4,7 @@ import fs from 'fs-extra';
 import { type z } from 'zod';
 import { app } from 'electron';
 
-import { DEFAULT_LAUNCHER_UPDATE_URL } from '~common/constants';
+import { DEFAULT_LAUNCHER_UPDATE_URL, DEFAULT_REALMLIST } from '~common/constants';
 import { PreferencesSchema } from '~common/schemas';
 import { omit } from '~common/utils';
 
@@ -12,7 +12,8 @@ const portableDir = process.env.PORTABLE_EXECUTABLE_DIR;
 
 abstract class Preferences {
         static #data: z.infer<typeof PreferencesSchema> = PreferencesSchema.parse({
-                launcherUpdateUrl: DEFAULT_LAUNCHER_UPDATE_URL
+                launcherUpdateUrl: DEFAULT_LAUNCHER_UPDATE_URL,
+                realmList: DEFAULT_REALMLIST
         });
 
 	static readonly userDataDir = process.env.PORTABLE_EXECUTABLE_DIR

--- a/src/renderer/components/PreferencesDialog.tsx
+++ b/src/renderer/components/PreferencesDialog.tsx
@@ -2,7 +2,7 @@ import { Download, FolderPen } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
 import { api } from '~renderer/utils/api';
-import { DEFAULT_LAUNCHER_UPDATE_URL } from '~common/constants';
+import { DEFAULT_LAUNCHER_UPDATE_URL, DEFAULT_REALMLIST } from '~common/constants';
 
 import TextButton from './styled/TextButton';
 import CheckboxInput from './form/CheckboxInput';
@@ -19,10 +19,15 @@ const PreferencesDialog = ({ close }: Props) => {
         const update = api.updater.update.useMutation();
 
         const [launcherUpdateUrl, setLauncherUpdateUrl] = useState('');
+        const [realmList, setRealmList] = useState('');
 
         useEffect(() => {
                 setLauncherUpdateUrl(pref?.launcherUpdateUrl ?? DEFAULT_LAUNCHER_UPDATE_URL);
         }, [pref?.launcherUpdateUrl]);
+
+        useEffect(() => {
+                setRealmList(pref?.realmList ?? DEFAULT_REALMLIST);
+        }, [pref?.realmList]);
 
         const persistLauncherUpdateUrl = async () => {
                 const trimmed = launcherUpdateUrl.trim();
@@ -45,10 +50,34 @@ const PreferencesDialog = ({ close }: Props) => {
                 }
         };
 
-	return (
-		<div className="dialog">
-			<CloseButton close={close} />
-			<h2 className="color mb-2 text-xl">Settings</h2>
+        const persistRealmList = async () => {
+                const trimmed = realmList.trim();
+                if (!pref) return;
+                if (!trimmed) {
+                        setRealmList(pref.realmList);
+                        return;
+                }
+
+                if (trimmed === pref.realmList) return;
+
+                try {
+                        const updated = await setPref.mutateAsync({
+                                realmList: trimmed
+                        });
+                        setRealmList(updated.realmList);
+                } catch (error) {
+                        setRealmList(pref.realmList);
+                        console.error(error);
+                }
+        };
+
+        const inputClassName =
+                'rounded border border-text bg-dark/60 p-2 text-sm text-text placeholder:text-textDark focus:border-primary focus:outline-none';
+
+        return (
+                <div className="dialog">
+                        <CloseButton close={close} />
+                        <h2 className="color mb-2 text-xl">Settings</h2>
 
 			<div className="flex w-full flex-col">
 				<h3 className="color text-lg">Game</h3>
@@ -71,16 +100,35 @@ const PreferencesDialog = ({ close }: Props) => {
 						)}
 					</DialogButton>
 				</div>
-				<CheckboxInput
-					value={pref?.cleanWdb ?? false}
-					setValue={v => setPref.mutateAsync({ cleanWdb: v })}
-					label="Clean WDB on each launch"
-				/>
-			</div>
+                                <CheckboxInput
+                                        value={pref?.cleanWdb ?? false}
+                                        setValue={v => setPref.mutateAsync({ cleanWdb: v })}
+                                        label="Clean WDB on each launch"
+                                />
+                                <div className="mt-3 flex flex-col gap-1 pl-2">
+                                        <label htmlFor="realm-list" className="text-sm text-text">
+                                                Realmlist server
+                                        </label>
+                                        <input
+                                                id="realm-list"
+                                                className={inputClassName}
+                                                value={realmList}
+                                                onChange={event => setRealmList(event.target.value)}
+                                                onBlur={persistRealmList}
+                                                onKeyDown={event => {
+                                                        if (event.key === 'Enter') {
+                                                                event.preventDefault();
+                                                                event.currentTarget.blur();
+                                                        }
+                                                }}
+                                                placeholder={DEFAULT_REALMLIST}
+                                        />
+                                </div>
+                        </div>
 
-			<div className="flex flex-col">
-				<h3 className="color text-lg">Launcher</h3>
-				<CheckboxInput
+                        <div className="flex flex-col">
+                                <h3 className="color text-lg">Launcher</h3>
+                                <CheckboxInput
 					value={pref?.reopenLauncher ?? false}
 					setValue={v => setPref.mutateAsync({ reopenLauncher: v })}
 					label="Reopen launcher after WoW closes"
@@ -99,7 +147,7 @@ const PreferencesDialog = ({ close }: Props) => {
                                         </label>
                                         <input
                                                 id="launcher-update-url"
-                                                className="rounded border border-text bg-transparent p-2 text-sm text-text focus:border-primary focus:outline-none"
+                                                className={inputClassName}
                                                 value={launcherUpdateUrl}
                                                 onChange={event =>
                                                         setLauncherUpdateUrl(event.target.value)


### PR DESCRIPTION
## Summary
- add a default realmlist constant and persist it through the preferences schema
- allow the launcher settings dialog to edit the realmlist with improved input styling
- update the patcher to respect the stored realmlist when generating Config.wtf

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd3a27e6c883278d9463d56a90adde