### PR TITLE
Trigger dialog buttons on pointer press

### DIFF
--- a/src/renderer/components/styled/Button.tsx
+++ b/src/renderer/components/styled/Button.tsx
@@ -1,4 +1,4 @@
-import type { ButtonHTMLAttributes } from 'react';
+import type { ButtonHTMLAttributes, MouseEvent } from 'react';
 import cls from 'classnames';
 import { type LucideIcon } from 'lucide-react';
 
@@ -14,37 +14,63 @@ type Props = ButtonHTMLAttributes<HTMLButtonElement> & {
 };
 
 const Button = ({
-	primary,
-	loading,
-	disabled,
-	icon: Icon,
-	children,
-	className,
-	...props
-}: Props) => (
-	<button
-		{...props}
-		onClick={focusBlur(props.onClick)}
-		tabIndex={!!loading || !!disabled ? -1 : props.tabIndex}
-		className={cls(
-			'rounded border-2 border-border bg-dark px-5 py-3',
-			className,
-			{
-				'pointer-events-none': !!disabled || !!loading,
-				'grayscale': disabled,
-				'button-primary': primary
-			}
-		)}
-	>
-		<span className={cls('select-none', { 'ml-[-12px]': !!loading || !!Icon })}>
-			{loading ? (
-				<IconSpinner size={23} strokeWidth={1.5} />
-			) : Icon ? (
-				<Icon size={23} strokeWidth={1.5} />
-			) : null}
-			{children}
-		</span>
-	</button>
-);
+        primary,
+        loading,
+        disabled,
+        icon: Icon,
+        children,
+        className,
+        onClick,
+        onMouseDown,
+        tabIndex,
+        ...props
+}: Props) => {
+        const activate = focusBlur(onClick);
+        const triggerActivate = (event: MouseEvent<HTMLButtonElement>) => {
+                activate?.(
+                        event as Parameters<NonNullable<typeof activate>>[0]
+                );
+        };
+
+        const handleMouseDown = (event: MouseEvent<HTMLButtonElement>) => {
+                onMouseDown?.(event);
+                if (!event.defaultPrevented && event.button === 0) {
+                        triggerActivate(event);
+                }
+        };
+
+        const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
+                if (event.detail === 0) {
+                        triggerActivate(event);
+                }
+        };
+
+        return (
+                <button
+                        {...props}
+                        onMouseDown={handleMouseDown}
+                        onClick={handleClick}
+                        tabIndex={!!loading || !!disabled ? -1 : tabIndex}
+                        className={cls(
+                                'rounded border-2 border-border bg-dark px-5 py-3',
+                                className,
+                                {
+                                        'pointer-events-none': !!disabled || !!loading,
+                                        'grayscale': disabled,
+                                        'button-primary': primary
+                                }
+                        )}
+                >
+                        <span className={cls('select-none', { 'ml-[-12px]': !!loading || !!Icon })}>
+                                {loading ? (
+                                        <IconSpinner size={23} strokeWidth={1.5} />
+                                ) : Icon ? (
+                                        <Icon size={23} strokeWidth={1.5} />
+                                ) : null}
+                                {children}
+                        </span>
+                </button>
+        );
+};
 
 export default Button;

--- a/src/renderer/components/styled/TextButton.tsx
+++ b/src/renderer/components/styled/TextButton.tsx
@@ -1,21 +1,30 @@
 import cls from 'classnames';
 import { type LucideIcon } from 'lucide-react';
-import { type ReactNode } from 'react';
+import {
+        type ButtonHTMLAttributes,
+        type MouseEvent,
+        type ReactNode
+} from 'react';
 
 import { focusBlur } from '~common/utils';
 
 import IconSpinner from './IconSpinner';
 
-type Props = {
-	active?: boolean;
-	loading?: boolean;
-	disabled?: boolean;
-	size?: number;
-	className?: cls.Value;
-	style?: React.CSSProperties;
+type BaseProps = Omit<
+        ButtonHTMLAttributes<HTMLButtonElement>,
+        'onClick' | 'type' | 'children'
+>;
+
+type Props = BaseProps & {
+        active?: boolean;
+        loading?: boolean;
+        disabled?: boolean;
+        size?: number;
+        className?: cls.Value;
+        style?: React.CSSProperties;
 } & (
-	| { type: 'submit'; onClick?: never }
-	| { type?: never; onClick: () => void }
+        | { type: 'submit'; onClick?: never }
+        | { type?: never; onClick: () => void }
 ) &
 	(
 		| { children: ReactNode; icon?: LucideIcon; title?: never }
@@ -23,45 +32,71 @@ type Props = {
 	);
 
 const TextButton = ({
-	title,
-	type,
-	active,
-	loading,
-	disabled,
-	icon: Icon,
-	size,
-	onClick,
-	className,
-	children,
-	...props
-}: Props) => (
-	<button
-		title={title ?? (typeof children === 'string' ? children : undefined)}
-		type={type ?? 'button'}
-		onClick={focusBlur(onClick ?? true)}
-		tabIndex={!!loading || !!disabled ? -1 : undefined}
-		className={cls(
-			'flex cursor-pointer items-center gap-2 border-0 p-2',
-			className,
-			{
-				'drop-shadow-[0px_0px_10px_white]': active && !loading && !disabled,
-				'text-gray pointer-events-none': !!loading || !!disabled,
-				'hocus': !loading && !disabled
-			}
-		)}
-		{...props}
-	>
-		{loading ? (
-			<IconSpinner size={size ?? 24} strokeWidth={1.5} />
-		) : (
-			Icon && <Icon size={size} />
-		)}
-		{children && (
-			<span className="cursor-pointer select-none tracking-wide text-inherit [font-size:_inherit]">
-				{children}
-			</span>
-		)}
-	</button>
-);
+        title,
+        type,
+        active,
+        loading,
+        disabled,
+        icon: Icon,
+        size,
+        onClick,
+        onMouseDown,
+        className,
+        children,
+        ...props
+}: Props) => {
+        const { tabIndex, ...rest } = props;
+
+        const activate = focusBlur(onClick ?? true);
+        const triggerActivate = (event: MouseEvent<HTMLButtonElement>) => {
+                activate?.(
+                        event as Parameters<NonNullable<typeof activate>>[0]
+                );
+        };
+
+        const handleMouseDown = (event: MouseEvent<HTMLButtonElement>) => {
+                onMouseDown?.(event);
+                if (!event.defaultPrevented && event.button === 0) {
+                        triggerActivate(event);
+                }
+        };
+
+        const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
+                if (event.detail === 0) {
+                        triggerActivate(event);
+                }
+        };
+
+        return (
+                <button
+                        title={title ?? (typeof children === 'string' ? children : undefined)}
+                        type={type ?? 'button'}
+                        onMouseDown={handleMouseDown}
+                        onClick={handleClick}
+                        tabIndex={!!loading || !!disabled ? -1 : tabIndex}
+                        className={cls(
+                                'flex cursor-pointer items-center gap-2 border-0 p-2',
+                                className,
+                                {
+                                        'drop-shadow-[0px_0px_10px_white]': active && !loading && !disabled,
+                                        'text-gray pointer-events-none': !!loading || !!disabled,
+                                        'hocus': !loading && !disabled
+                                }
+                        )}
+                        {...rest}
+                >
+                        {loading ? (
+                                <IconSpinner size={size ?? 24} strokeWidth={1.5} />
+                        ) : (
+                                Icon && <Icon size={size} />
+                        )}
+                        {children && (
+                                <span className="cursor-pointer select-none tracking-wide text-inherit [font-size:_inherit]">
+                                        {children}
+                                </span>
+                        )}
+                </button>
+        );
+};
 
 export default TextButton;


### PR DESCRIPTION
## Summary
- update styled button components to activate on pointer down so dialogs open immediately
- preserve keyboard accessibility by only handling click events originating from keyboard interaction

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd457033608327afa850bc392072c2