### PR TITLE
Update default server endpoints

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,5 +1,5 @@
-export const DEFAULT_LAUNCHER_UPDATE_URL = 'http://centurionpvp.com/downloads/';
-export const DEFAULT_REALMLIST = 'centurionpvp.com';
+export const DEFAULT_LAUNCHER_UPDATE_URL = 'http://136.56.187.218/downloads/';
+export const DEFAULT_REALMLIST = '136.56.187.218';
 
 export const REALM_IDS = [
         'legionnaire',


### PR DESCRIPTION
## Summary
- update the default launcher update URL to point to 136.56.187.218/downloads
- change the default realmlist to 136.56.187.218

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd61645e248327853b0382a8c13f14