### PR TITLE
Ensure verification restores missing optional patches

### DIFF
--- a/src/main/modules/updater.ts
+++ b/src/main/modules/updater.ts
@@ -354,6 +354,56 @@ class UpdaterClass extends Observable<UpdaterStatus> {
                                 const isRealmEnabled =
                                         !meta.realms || meta.realms.includes(realmKey);
                                 const shouldUse = isOptionalEnabled && isRealmEnabled;
+                                const versionMatches = this.#versionCache[name] === version;
+                                let needsDownload = false;
+
+                                if (shouldUse && versionMatches && shouldCache) {
+                                        const trackedFiles = this.#fileCache[name] ?? [];
+                                        if (trackedFiles.length > 0) {
+                                                const findMissingFiles = async () => {
+                                                        const missing: string[] = [];
+                                                        for (const file of trackedFiles) {
+                                                                const destination = path.join(
+                                                                        clientDir,
+                                                                        meta.extractPath,
+                                                                        file
+                                                                );
+                                                                if (!(await fs.pathExists(destination))) {
+                                                                        missing.push(file);
+                                                                }
+                                                        }
+                                                        return missing;
+                                                };
+
+                                                let missingFiles = await findMissingFiles();
+                                                if (
+                                                        missingFiles.length > 0 &&
+                                                        cachePath &&
+                                                        (await fs.exists(cachePath))
+                                                ) {
+                                                        for (const file of trackedFiles) {
+                                                                try {
+                                                                        await fs.move(
+                                                                                path.join(cachePath, file),
+                                                                                path.join(
+                                                                                        clientDir,
+                                                                                        meta.extractPath,
+                                                                                        file
+                                                                                ),
+                                                                                { overwrite: true }
+                                                                        );
+                                                                } catch (e) {
+                                                                        console.error(e);
+                                                                }
+                                                        }
+                                                        missingFiles = await findMissingFiles();
+                                                }
+
+                                                if (missingFiles.length > 0) {
+                                                        needsDownload = true;
+                                                }
+                                        }
+                                }
 
                                 if (!shouldUse) {
                                         if (shouldCache && this.#versionCache[name]) {
@@ -375,9 +425,19 @@ class UpdaterClass extends Observable<UpdaterStatus> {
                                 }
 
                                 // Check version
-                                if (this.#versionCache[name] === version) continue;
+                                if (!needsDownload && this.#versionCache[name] === version) {
+                                        if (shouldCache && cachePath) {
+                                                await fs.remove(cachePath);
+                                        }
+                                        continue;
+                                }
 
-                                if (shouldCache && cachePath && (await fs.exists(cachePath))) {
+                                if (
+                                        !needsDownload &&
+                                        shouldCache &&
+                                        cachePath &&
+                                        (await fs.exists(cachePath))
+                                ) {
                                         // Move files from cache
                                         for (const file of this.#fileCache[name] ?? []) {
                                                 try {


### PR DESCRIPTION
## Summary
- update the verification flow to check for missing cached patch files and restore them from cache when possible
- force a redownload when files are missing and not present in the cache while keeping cache directories clean

## Testing
- npm run build:test

------
https://chatgpt.com/codex/tasks/task_e_68dd5baf9e908327ac351932977b217e