### PR TITLE
Restore latest.yaml for portable workflow

### DIFF
--- a/latest.yaml
+++ b/latest.yaml
@@ -1,0 +1,5 @@
+version: 1.0.1
+releaseDate: '2024-05-14T00:00:00.000Z'
+files:
+  - url: CenturionLauncher.exe
+    type: portable

--- a/src/main/modules/updater.ts
+++ b/src/main/modules/updater.ts
@@ -320,7 +320,7 @@ class UpdaterClass extends Observable<UpdaterStatus> {
 
 			if (isPortable) {
 				await fs.remove(path.join(clientDir, 'update-script.bat'));
-				const version = await fetchVersion('latest.yml');
+                                const version = await fetchVersion('latest.yaml');
 				if (version.match(/version: (.*)/)?.[1] !== app.getVersion()) {
 					this.status = { state: 'launcherOutdated' };
 					return;


### PR DESCRIPTION
## Summary
- restore the `latest.yaml` metadata file with a portable launcher entry
- update the portable launcher version check to read `latest.yaml` again

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd792906c08327ae4e747022167710