### PR TITLE
Use launcher.version for portable update checks

### DIFF
--- a/src/main/modules/updater.ts
+++ b/src/main/modules/updater.ts
@@ -320,8 +320,8 @@ class UpdaterClass extends Observable<UpdaterStatus> {
 
 			if (isPortable) {
 				await fs.remove(path.join(clientDir, 'update-script.bat'));
-                                const version = await fetchVersion('latest.yaml');
-				if (version.match(/version: (.*)/)?.[1] !== app.getVersion()) {
+                                const version = await fetchVersion('launcher.version');
+                                if (version.trim() !== app.getVersion()) {
 					this.status = { state: 'launcherOutdated' };
 					return;
 				}


### PR DESCRIPTION
## Summary
- switch portable launcher update validation to read the dedicated launcher.version file
- compare the remote launcher version directly against the installed app version

## Testing
- npm run build:test

------
https://chatgpt.com/codex/tasks/task_e_68dd98cb1d908327bb812ff243b6a7b4