### PR TITLE
Clean cache folder before launching game

### DIFF
--- a/src/main/api/routers/launcher.ts
+++ b/src/main/api/routers/launcher.ts
@@ -20,10 +20,13 @@ export const launcherRouter = createTRPCRouter({
 		Logger.log(`Launching ${clientPath}...`);
 		if (await isGameRunning()) return false;
 
-		if (cleanWdb) {
-			Logger.log('Cleaning up WDB...');
-			await fs.remove(path.join(clientPath, 'WDB'));
-		}
+                if (cleanWdb) {
+                        Logger.log('Cleaning up WDB...');
+                        await fs.remove(path.join(clientDir, 'WDB'));
+                }
+
+                Logger.log('Cleaning up Cache...');
+                await fs.remove(path.join(clientDir, 'Cache'));
 
 		// Make sure config.wtf is correct
 		Logger.log('Checking Config.wtf...');


### PR DESCRIPTION
## Summary
- ensure the launcher always removes the Cache directory before starting the game
- fix the WDB cleanup path to point at the client directory instead of the executable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1fdc822348327984ac0fd6a566164