### PR TITLE
Simplify launcher self-update handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,8 @@ $ npm run dist
 ```
 
 > The Windows build now produces only the portable executable (no installer).
+
+## Launcher self-update hosting
+
+See [docs/self-update.md](docs/self-update.md) for details on how to host the launcher
+archive and version file so that in-app self-updates work correctly.

--- a/docs/self-update.md
+++ b/docs/self-update.md
@@ -1,0 +1,31 @@
+# Launcher self-update hosting
+
+The launcher looks for updates at the URL configured in **Preferences → Update server**.
+If the user never changes it, the value defaults to `http://136.56.187.218/downloads/` (see
+`DEFAULT_LAUNCHER_UPDATE_URL`).
+
+To publish a new build:
+
+1. Upload a `centurionlauncher.zip` archive to the root of the update URL. With the default
+   configuration this means `http://136.56.187.218/downloads/centurionlauncher.zip`. The
+   archive must include the launcher executable and the `.launcher` directory from the
+   shipped build.
+2. Place a `centurionlauncher.version` text file alongside the archive (for the default URL,
+   `http://136.56.187.218/downloads/centurionlauncher.version`). The file should
+   contain only the version string that matches the packaged build, for example:
+
+   ```
+   1.2.3
+   ```
+
+When the launcher sees that the version in `centurionlauncher.version` is newer than its
+current `app.getVersion()`, it downloads `centurionlauncher.zip`, extracts just the
+executable that matches the running process name, and swaps it in place without touching the
+existing `%APPDATA%/.launcher` data directory.
+
+## Failure behaviour
+
+If the version file or archive cannot be downloaded (404, network issue, empty version file,
+missing executable in the zip, etc.), the launcher logs the issue, displays a notice in the
+client UI, and proceeds with normal file verification so players can continue launching the
+game.

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -102,6 +102,7 @@ export const FileMap: Record<
         ['patch-enUS-8']: { extractPath: 'Data/enUS', realms: ['legionnaire_plus'] },
         ['patch-enUS-9']: { extractPath: 'Data/enUS', realms: ['barracks', 'barracks_plus'] },
         ['patch-enUS-10']: { extractPath: 'Data/enUS', realms: ['barracks_plus'] },
+        ['patch-dungeon-maps']: { extractPath: 'Data', realms: ['barracks', 'townsendboys'] },
         ['hd-creatures']: {
                 extractPath: 'Data',
                 optional: true,

--- a/src/main/api/routers/updater.ts
+++ b/src/main/api/routers/updater.ts
@@ -7,8 +7,9 @@ import { createTRPCRouter, publicProcedure } from '../trpc';
 export const updaterRouter = createTRPCRouter({
 	invalidate: publicProcedure.mutation(() => Updater.invalidate()),
 	verify: publicProcedure.mutation(() => Updater.verify()),
-	update: publicProcedure
-		.input(z.boolean().optional())
-		.mutation(({ input }) => Updater.update(input)),
+        update: publicProcedure
+                .input(z.boolean().optional())
+                .mutation(({ input }) => Updater.update(input)),
+        closeLauncher: publicProcedure.mutation(() => Updater.applyLauncherUpdate()),
         observe: publicProcedure.subscription(() => Updater.observe())
 });

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -21,12 +21,13 @@ const createWindow = async () => {
 		: { width: 800, height: 600 };
 
 	// Create the browser window.
-	mainWindow = new BrowserWindow({
-		...position,
-		minWidth: 800,
-		minHeight: 600,
-		icon,
-		frame: false,
+        mainWindow = new BrowserWindow({
+                ...position,
+                minWidth: 800,
+                minHeight: 600,
+                backgroundColor: '#050505',
+                icon,
+                frame: false,
 		webPreferences: {
 			preload: join(__dirname, '../preload/index.js'),
 			contextIsolation: true,
@@ -71,25 +72,28 @@ const createWindow = async () => {
 app.whenReady().then(async () => {
         // Initialization
         Preferences.data = await Preferences.load();
-        const launcherUpdateTriggered = await Updater.updateLauncher();
-        if (launcherUpdateTriggered) return;
+        await createWindow();
+
+        await Updater.updateLauncher();
         Updater.verify();
 
-	// Set app user model id for windows
-	electronApp.setAppUserModelId('com.electron');
+        // Set app user model id for windows
+        electronApp.setAppUserModelId('com.electron');
 
 	// Default open or close DevTools by F12 in development
 	// and ignore CommandOrControl + R in production.
 	// see https://github.com/alex8088/electron-toolkit/tree/master/packages/utils
-	app.on('browser-window-created', (_, window) => {
-		optimizer.watchWindowShortcuts(window);
-	});
-
-	await createWindow();
+        app.on('browser-window-created', (_, window) => {
+                optimizer.watchWindowShortcuts(window);
+        });
 });
 
 // Quit when all windows are closed
 app.on('window-all-closed', async () => {
-	await Logger.saveLog();
-	app.quit();
+        await Logger.saveLog();
+        app.quit();
+});
+
+app.on('before-quit', () => {
+        Updater.handleLauncherBeforeQuit();
 });

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -69,9 +69,11 @@ const createWindow = async () => {
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
 app.whenReady().then(async () => {
-	// Initialization
-	Preferences.data = await Preferences.load();
-	Updater.verify();
+        // Initialization
+        Preferences.data = await Preferences.load();
+        const launcherUpdateTriggered = await Updater.updateLauncher();
+        if (launcherUpdateTriggered) return;
+        Updater.verify();
 
 	// Set app user model id for windows
 	electronApp.setAppUserModelId('com.electron');

--- a/src/main/modules/resumableFetch.ts
+++ b/src/main/modules/resumableFetch.ts
@@ -51,11 +51,17 @@ const resumableFetch = async (
 		Logger.log(`Downloading "${downloadPath}"`);
 	}
 
-	const response = await fetch(url, {
-		headers: { Range: `bytes=${initialPartial}-` }
-	});
+        const response = await fetch(url, {
+                headers: { Range: `bytes=${initialPartial}-` }
+        });
 
-	const total = Number(response.headers.get('content-length'));
+        if (!response.ok && response.status !== 206) {
+                throw new Error(
+                        `Failed to download ${url}: ${response.status} ${response.statusText}`
+                );
+        }
+
+        const total = Number(response.headers.get('content-length'));
 	const startedAt = Date.now();
 
 	const throttled = throttle(options.throttle ?? 0, () => {

--- a/src/main/modules/updater.ts
+++ b/src/main/modules/updater.ts
@@ -1,10 +1,12 @@
 import path from 'node:path';
-import { exec } from 'node:child_process';
+import { exec, spawn } from 'node:child_process';
 import os from 'node:os';
 
 import fetch from 'node-fetch';
 import fs from 'fs-extra';
 import yauzl from 'yauzl-promise';
+
+import { app } from 'electron';
 
 import { mainWindow } from '~main/index';
 import { formatDuration, formatFileSize } from '~common/utils';
@@ -22,6 +24,9 @@ const resolveBaseUrl = () => {
 
 const resolvePatchUrl = (filePath: string) =>
         new URL(`patches/${filePath.replace(/^\/+/, '')}`, resolveBaseUrl()).toString();
+
+const resolveLauncherUrl = (filePath: string) =>
+        new URL(filePath.replace(/^\/+/, ''), resolveBaseUrl()).toString();
 
 // const isReadOnly = async (filePath: string) => {
 // 	try {
@@ -114,6 +119,40 @@ const fetchVersion = async (filePath: string) => {
                 throw Error(`Failed to download ${filePath}`);
         }
 };
+
+const compareVersions = (a: string, b: string) => {
+        const parse = (version: string) =>
+                version
+                        .split(/[^0-9]+/)
+                        .filter(Boolean)
+                        .map(part => Number.parseInt(part, 10));
+
+        const left = parse(a);
+        const right = parse(b);
+        const length = Math.max(left.length, right.length);
+
+        for (let i = 0; i < length; i += 1) {
+                const leftPart = left[i] ?? 0;
+                const rightPart = right[i] ?? 0;
+                if (leftPart > rightPart) return 1;
+                if (leftPart < rightPart) return -1;
+        }
+
+        return 0;
+};
+
+const parseLauncherManifest = (manifest: string) => {
+        const versionMatch = manifest.match(/^version:\s*([^\s]+)\s*$/m);
+        if (!versionMatch) return undefined;
+
+        const fileMatch = manifest.match(/^-\s+url:\s*(\S+)\s*$/m);
+        return {
+                version: versionMatch[1].trim(),
+                file: fileMatch?.[1]?.trim()
+        };
+};
+
+const escapeForBatch = (value: string) => value.replace(/\\/g, '\\\\');
 
 type ExtractProgressCallback = (progress: number | null, percent?: number) => void;
 
@@ -287,11 +326,138 @@ class UpdaterClass extends Observable<UpdaterStatus> {
 	}
 
         async updateLauncher() {
-                Logger.log('Launcher updates are currently disabled.');
-                this.status = {
-                        state: 'failed',
-                        message: 'Launcher updates are currently disabled. Please download the latest release manually.'
-                };
+                if (os.platform() !== 'win32') return false;
+                if (!app.isPackaged) {
+                        Logger.log('Skipping launcher update in development environment.');
+                        return false;
+                }
+
+                let updatePath: string | undefined;
+                let scriptPath: string | undefined;
+                let downloadPath: string | undefined;
+
+                try {
+                        const manifestResponse = await fetch(
+                                resolveLauncherUrl('latest.yaml')
+                        );
+
+                        if (!manifestResponse.ok) {
+                                Logger.log('Failed to fetch launcher manifest. Skipping update.');
+                                return false;
+                        }
+
+                        const manifest = parseLauncherManifest(await manifestResponse.text());
+                        if (!manifest) {
+                                Logger.log('Launcher manifest is invalid. Skipping update.');
+                                return false;
+                        }
+
+                        const currentVersion = app.getVersion();
+                        if (compareVersions(manifest.version, currentVersion) <= 0) {
+                                Logger.log('Launcher is up to date.');
+                                return false;
+                        }
+
+                        const fileName = manifest.file ?? path.basename(process.execPath);
+                        Logger.log(
+                                `New launcher version available (${manifest.version}). Downloading ${fileName}...`
+                        );
+
+                        await fs.ensureDir(path.join(Preferences.userDataDir, 'downloads'));
+                        downloadPath = path.join(
+                                Preferences.userDataDir,
+                                'downloads',
+                                fileName
+                        );
+                        await fs.ensureDir(path.dirname(downloadPath));
+
+                        await resumableFetch(resolveLauncherUrl(fileName), downloadPath, undefined, {
+                                throttle: 500
+                        });
+
+                        const execDir = process.env.PORTABLE_EXECUTABLE_DIR
+                                ? process.env.PORTABLE_EXECUTABLE_DIR
+                                : path.dirname(process.execPath);
+                        const execName = path.basename(process.execPath);
+                        updatePath = path.join(execDir, `${execName}.update`);
+                        await fs.copy(downloadPath, updatePath, { overwrite: true });
+                        await fs.remove(downloadPath);
+                        downloadPath = undefined;
+
+                        const backupPath = path.join(execDir, `${execName}.old`);
+                        const escapedUpdatePath = escapeForBatch(updatePath);
+                        const escapedTargetPath = escapeForBatch(process.execPath);
+                        const escapedBackupPath = escapeForBatch(backupPath);
+                        scriptPath = path.join(execDir, 'update-launcher.bat');
+                        const processName = execName;
+                        const scriptContent = [
+                                '@echo off',
+                                'setlocal enableextensions',
+                                `set "SOURCE=${escapedUpdatePath}"`,
+                                `set "TARGET=${escapedTargetPath}"`,
+                                `set "BACKUP=${escapedBackupPath}"`,
+                                `set "PROCESS_NAME=${processName}"`,
+                                ':waitloop',
+                                'tasklist /FI "IMAGENAME eq %PROCESS_NAME%" | find /I "%PROCESS_NAME%" >NUL',
+                                'if %ERRORLEVEL%==0 (',
+                                '    timeout /t 1 >NUL',
+                                '    goto waitloop',
+                                ')',
+                                'if exist "%BACKUP%" del /f /q "%BACKUP%" >NUL 2>&1',
+                                'if exist "%TARGET%" move /Y "%TARGET%" "%BACKUP%" >NUL 2>&1',
+                                'move /Y "%SOURCE%" "%TARGET%" >NUL 2>&1',
+                                'start "" "%TARGET%"',
+                                'del "%~f0" >NUL 2>&1',
+                                'exit /b 0'
+                        ].join('\r\n');
+
+                        await fs.writeFile(scriptPath, scriptContent, 'utf8');
+
+                        spawn('cmd.exe', ['/c', 'start', '""', scriptPath], {
+                                detached: true,
+                                stdio: 'ignore'
+                        }).unref();
+
+                        Logger.log('Launcher update downloaded. Restarting to apply update.');
+                        app.quit();
+                        return true;
+                } catch (error) {
+                        Logger.log('Failed to update launcher', 'error', error);
+                        if (downloadPath) {
+                                try {
+                                        await fs.remove(downloadPath);
+                                } catch (cleanupError) {
+                                        Logger.log(
+                                                'Failed to clean up launcher download',
+                                                'error',
+                                                cleanupError
+                                        );
+                                }
+                        }
+                        if (updatePath) {
+                                try {
+                                        await fs.remove(updatePath);
+                                } catch (cleanupError) {
+                                        Logger.log(
+                                                'Failed to clean up launcher update file',
+                                                'error',
+                                                cleanupError
+                                        );
+                                }
+                        }
+                        if (scriptPath) {
+                                try {
+                                        await fs.remove(scriptPath);
+                                } catch (cleanupError) {
+                                        Logger.log(
+                                                'Failed to clean up launcher update script',
+                                                'error',
+                                                cleanupError
+                                        );
+                                }
+                        }
+                        return false;
+                }
         }
 
 	async verify() {

--- a/src/main/modules/updater.ts
+++ b/src/main/modules/updater.ts
@@ -1,10 +1,12 @@
 import path from 'node:path';
-import { exec } from 'node:child_process';
+import { exec, spawn } from 'node:child_process';
 import os from 'node:os';
 
 import fetch from 'node-fetch';
 import fs from 'fs-extra';
 import yauzl from 'yauzl-promise';
+
+import { app } from 'electron';
 
 import { mainWindow } from '~main/index';
 import { formatDuration, formatFileSize } from '~common/utils';
@@ -22,6 +24,12 @@ const resolveBaseUrl = () => {
 
 const resolvePatchUrl = (filePath: string) =>
         new URL(`patches/${filePath.replace(/^\/+/, '')}`, resolveBaseUrl()).toString();
+
+const resolveLauncherUrl = (filePath: string) =>
+        new URL(filePath.replace(/^\/+/, ''), resolveBaseUrl()).toString();
+
+const LAUNCHER_VERSION_FILE = 'centurionlauncher.version';
+const LAUNCHER_ARCHIVE_FILE = 'centurionlauncher.zip';
 
 // const isReadOnly = async (filePath: string) => {
 // 	try {
@@ -115,6 +123,29 @@ const fetchVersion = async (filePath: string) => {
         }
 };
 
+const compareVersions = (a: string, b: string) => {
+        const parse = (version: string) =>
+                version
+                        .split(/[^0-9]+/)
+                        .filter(Boolean)
+                        .map(part => Number.parseInt(part, 10));
+
+        const left = parse(a);
+        const right = parse(b);
+        const length = Math.max(left.length, right.length);
+
+        for (let i = 0; i < length; i += 1) {
+                const leftPart = left[i] ?? 0;
+                const rightPart = right[i] ?? 0;
+                if (leftPart > rightPart) return 1;
+                if (leftPart < rightPart) return -1;
+        }
+
+        return 0;
+};
+
+const escapeForBatch = (value: string) => value.replace(/\\/g, '\\\\');
+
 type ExtractProgressCallback = (progress: number | null, percent?: number) => void;
 
 const extractArchive = async (
@@ -197,15 +228,21 @@ type UpdaterState =
         | 'failed';
 
 export type UpdaterStatus = {
-	state: UpdaterState;
-	progress?: number;
-	message?: string;
+        state: UpdaterState;
+        progress?: number;
+        message?: string;
+        notice?: string;
 };
 
 class UpdaterClass extends Observable<UpdaterStatus> {
         #versionCache: Record<string, string> = {};
         #fileCache: Record<string, string[]> = {};
         #pendingInvalidations = new Set<string>();
+        #statusNotice?: string;
+
+        #setNotice(message?: string) {
+                this.#statusNotice = message;
+        }
 
         #cachePatchFiles = async (
                 clientDir: string,
@@ -268,14 +305,18 @@ class UpdaterClass extends Observable<UpdaterStatus> {
 		return this._value;
 	}
 
-	private set status(v: UpdaterStatus) {
-		this._value = v;
-		this._notifyObservers(v);
-		if (this.status.state === 'failed') {
-			mainWindow?.setProgressBar(1, { mode: 'error' });
-		} else if (this.status.progress === 1) {
-			mainWindow?.setProgressBar(0);
-		} else {
+        private set status(v: UpdaterStatus) {
+                const next: UpdaterStatus = {
+                        ...v,
+                        notice: v.notice ?? this.#statusNotice
+                };
+                this._value = next;
+                this._notifyObservers(next);
+                if (this.status.state === 'failed') {
+                        mainWindow?.setProgressBar(1, { mode: 'error' });
+                } else if (this.status.progress === 1) {
+                        mainWindow?.setProgressBar(0);
+                } else {
 			mainWindow?.setProgressBar(this.status.progress ?? 0, {
 				mode: this.status.progress === -1 ? 'indeterminate' : 'normal'
 			});
@@ -287,11 +328,198 @@ class UpdaterClass extends Observable<UpdaterStatus> {
 	}
 
         async updateLauncher() {
-                Logger.log('Launcher updates are currently disabled.');
-                this.status = {
-                        state: 'failed',
-                        message: 'Launcher updates are currently disabled. Please download the latest release manually.'
-                };
+                if (os.platform() !== 'win32') return false;
+                if (!app.isPackaged) {
+                        Logger.log('Skipping launcher update in development environment.');
+                        return false;
+                }
+
+                this.#setNotice(undefined);
+                let updatePath: string | undefined;
+                let scriptPath: string | undefined;
+                let downloadPath: string | undefined;
+                let extractPath: string | undefined;
+
+                try {
+                        const versionResponse = await fetch(
+                                resolveLauncherUrl(LAUNCHER_VERSION_FILE)
+                        );
+
+                        if (!versionResponse.ok) {
+                                Logger.log('Failed to fetch launcher version file. Skipping update.');
+                                this.#setNotice(
+                                        `Self-update skipped: no launcher version file found at ${resolveLauncherUrl(
+                                                LAUNCHER_VERSION_FILE
+                                        )}`
+                                );
+                                return false;
+                        }
+
+                        const versionText = (await versionResponse.text()).trim();
+                        if (!versionText) {
+                                Logger.log('Launcher version file is empty. Skipping update.');
+                                this.#setNotice(
+                                        'Self-update skipped: launcher version file does not contain a version.'
+                                );
+                                return false;
+                        }
+
+                        const currentVersion = app.getVersion();
+                        if (compareVersions(versionText, currentVersion) <= 0) {
+                                Logger.log('Launcher is up to date.');
+                                return false;
+                        }
+
+                        Logger.log(
+                                `New launcher version available (${versionText}). Downloading ${LAUNCHER_ARCHIVE_FILE}...`
+                        );
+
+                        await fs.ensureDir(path.join(Preferences.userDataDir, 'downloads'));
+                        downloadPath = path.join(
+                                Preferences.userDataDir,
+                                'downloads',
+                                LAUNCHER_ARCHIVE_FILE
+                        );
+                        await fs.ensureDir(path.dirname(downloadPath));
+
+                        await resumableFetch(
+                                resolveLauncherUrl(LAUNCHER_ARCHIVE_FILE),
+                                downloadPath,
+                                undefined,
+                                {
+                                        throttle: 500
+                                }
+                        );
+
+                        const execDir = process.env.PORTABLE_EXECUTABLE_DIR
+                                ? process.env.PORTABLE_EXECUTABLE_DIR
+                                : path.dirname(process.execPath);
+                        const execName = path.basename(process.execPath);
+                        extractPath = path.join(
+                                Preferences.userDataDir,
+                                'downloads',
+                                `launcher-extract-${Date.now()}`
+                        );
+                        await fs.ensureDir(extractPath);
+
+                        const extractedFiles = await extractArchive(
+                                'launcher',
+                                downloadPath,
+                                extractPath
+                        );
+                        downloadPath = undefined;
+
+                        const executableEntry = extractedFiles.find(
+                                entry => path.basename(entry) === execName
+                        );
+
+                        if (!executableEntry) {
+                                throw new Error(`Launcher archive did not contain ${execName}.`);
+                        }
+
+                        const extractedExecutablePath = path.join(
+                                extractPath,
+                                executableEntry
+                        );
+
+                        updatePath = path.join(execDir, `${execName}.update`);
+                        await fs.copy(extractedExecutablePath, updatePath, { overwrite: true });
+
+                        const backupPath = path.join(execDir, `${execName}.old`);
+                        const escapedUpdatePath = escapeForBatch(updatePath);
+                        const escapedTargetPath = escapeForBatch(process.execPath);
+                        const escapedBackupPath = escapeForBatch(backupPath);
+                        scriptPath = path.join(execDir, 'update-launcher.bat');
+                        const processName = execName;
+                        const scriptContent = [
+                                '@echo off',
+                                'setlocal enableextensions',
+                                `set "SOURCE=${escapedUpdatePath}"`,
+                                `set "TARGET=${escapedTargetPath}"`,
+                                `set "BACKUP=${escapedBackupPath}"`,
+                                `set "PROCESS_NAME=${processName}"`,
+                                ':waitloop',
+                                'tasklist /FI "IMAGENAME eq %PROCESS_NAME%" | find /I "%PROCESS_NAME%" >NUL',
+                                'if %ERRORLEVEL%==0 (',
+                                '    timeout /t 1 >NUL',
+                                '    goto waitloop',
+                                ')',
+                                'if exist "%BACKUP%" del /f /q "%BACKUP%" >NUL 2>&1',
+                                'if exist "%TARGET%" move /Y "%TARGET%" "%BACKUP%" >NUL 2>&1',
+                                'move /Y "%SOURCE%" "%TARGET%" >NUL 2>&1',
+                                'start "" "%TARGET%"',
+                                'del "%~f0" >NUL 2>&1',
+                                'exit /b 0'
+                        ].join('\r\n');
+
+                        await fs.writeFile(scriptPath, scriptContent, 'utf8');
+
+                        if (extractPath) {
+                                await fs.remove(extractPath);
+                                extractPath = undefined;
+                        }
+
+                        spawn('cmd.exe', ['/c', 'start', '""', scriptPath], {
+                                detached: true,
+                                stdio: 'ignore'
+                        }).unref();
+
+                        Logger.log('Launcher update downloaded. Restarting to apply update.');
+                        app.quit();
+                        return true;
+                } catch (error) {
+                        Logger.log('Failed to update launcher', 'error', error);
+                        const message =
+                                error instanceof Error
+                                        ? error.message
+                                        : 'Unknown self-update error occurred';
+                        this.#setNotice(`Self-update failed: ${message}`);
+                        if (downloadPath) {
+                                try {
+                                        await fs.remove(downloadPath);
+                                } catch (cleanupError) {
+                                        Logger.log(
+                                                'Failed to clean up launcher download',
+                                                'error',
+                                                cleanupError
+                                        );
+                                }
+                        }
+                        if (updatePath) {
+                                try {
+                                        await fs.remove(updatePath);
+                                } catch (cleanupError) {
+                                        Logger.log(
+                                                'Failed to clean up launcher update file',
+                                                'error',
+                                                cleanupError
+                                        );
+                                }
+                        }
+                        if (scriptPath) {
+                                try {
+                                        await fs.remove(scriptPath);
+                                } catch (cleanupError) {
+                                        Logger.log(
+                                                'Failed to clean up launcher update script',
+                                                'error',
+                                                cleanupError
+                                        );
+                                }
+                        }
+                        if (extractPath) {
+                                try {
+                                        await fs.remove(extractPath);
+                                } catch (cleanupError) {
+                                        Logger.log(
+                                                'Failed to clean up launcher extraction directory',
+                                                'error',
+                                                cleanupError
+                                        );
+                                }
+                        }
+                        return false;
+                }
         }
 
 	async verify() {

--- a/src/main/modules/updater.ts
+++ b/src/main/modules/updater.ts
@@ -144,7 +144,9 @@ const compareVersions = (a: string, b: string) => {
         return 0;
 };
 
-const escapeForBatch = (value: string) => value.replace(/\\/g, '\\\\');
+const escapeForPowerShell = (value: string) => value.replace(/'/g, "''");
+const encodePowerShellCommand = (command: string) =>
+        Buffer.from(command, 'utf16le').toString('base64');
 
 type ExtractProgressCallback = (progress: number | null, percent?: number) => void;
 
@@ -227,11 +229,20 @@ type UpdaterState =
         | 'upToDate'
         | 'failed';
 
+type LauncherUpdateState = 'idle' | 'downloading' | 'pendingClose' | 'applying';
+
+type LauncherUpdateStatus = {
+        state: LauncherUpdateState;
+        progress?: number;
+        message?: string;
+};
+
 export type UpdaterStatus = {
         state: UpdaterState;
         progress?: number;
         message?: string;
         notice?: string;
+        launcher?: LauncherUpdateStatus;
 };
 
 class UpdaterClass extends Observable<UpdaterStatus> {
@@ -239,9 +250,12 @@ class UpdaterClass extends Observable<UpdaterStatus> {
         #fileCache: Record<string, string[]> = {};
         #pendingInvalidations = new Set<string>();
         #statusNotice?: string;
+        #pendingLauncherUpdateRunner: (() => void) | null = null;
+        #launcherUpdateScheduled = false;
 
         #setNotice(message?: string) {
                 this.#statusNotice = message;
+                this.#setStatus({ notice: message }, { preserveLauncher: true });
         }
 
         #cachePatchFiles = async (
@@ -299,33 +313,92 @@ class UpdaterClass extends Observable<UpdaterStatus> {
 		await fs.writeJSON(fileCache, this.#fileCache, { spaces: 2 });
 	};
 
-	protected _value: UpdaterStatus = { state: 'needsValidation' };
+        protected _value: UpdaterStatus = { state: 'needsValidation', progress: undefined };
 
-	get status() {
-		return this._value;
-	}
+        get status() {
+                return this._value;
+        }
 
-        private set status(v: UpdaterStatus) {
-                const next: UpdaterStatus = {
-                        ...v,
-                        notice: v.notice ?? this.#statusNotice
+        #applyStatus(next: UpdaterStatus) {
+                const merged: UpdaterStatus = {
+                        ...next,
+                        notice: next.notice ?? this.#statusNotice
                 };
-                this._value = next;
-                this._notifyObservers(next);
-                if (this.status.state === 'failed') {
-                        mainWindow?.setProgressBar(1, { mode: 'error' });
-                } else if (this.status.progress === 1) {
-                        mainWindow?.setProgressBar(0);
-                } else {
-			mainWindow?.setProgressBar(this.status.progress ?? 0, {
-				mode: this.status.progress === -1 ? 'indeterminate' : 'normal'
-			});
-		}
-	}
+                this._value = merged;
+                this._notifyObservers(merged);
 
-	invalidate() {
-		this.status = { state: 'needsValidation' };
-	}
+                const launcherState = merged.launcher?.state;
+                if (launcherState === 'downloading') {
+                        const launcherProgress = merged.launcher?.progress ?? 0;
+                        const mode = launcherProgress === -1 ? 'indeterminate' : 'normal';
+                        mainWindow?.setProgressBar(launcherProgress === -1 ? 0.5 : launcherProgress, {
+                                mode
+                        });
+                        return;
+                }
+
+                if (launcherState === 'pendingClose' || launcherState === 'applying') {
+                        mainWindow?.setProgressBar(1, { mode: 'normal' });
+                        return;
+                }
+
+                if (merged.state === 'failed') {
+                        mainWindow?.setProgressBar(1, { mode: 'error' });
+                        return;
+                }
+
+                if (merged.progress === 1) {
+                        mainWindow?.setProgressBar(0);
+                        return;
+                }
+
+                if (merged.progress === undefined) {
+                        mainWindow?.setProgressBar(0);
+                        return;
+                }
+
+                mainWindow?.setProgressBar(merged.progress ?? 0, {
+                        mode: merged.progress === -1 ? 'indeterminate' : 'normal'
+                });
+        }
+
+        #setStatus(
+                partial: Partial<UpdaterStatus>,
+                {
+                        replace = false,
+                        preserveLauncher = false
+                }: { replace?: boolean; preserveLauncher?: boolean } = {}
+        ) {
+                const base = replace ? ({} as UpdaterStatus) : this._value;
+                const nextState = (partial.state ?? base.state) ?? 'needsValidation';
+                const nextProgress = 'progress' in partial ? partial.progress : base.progress;
+                const nextMessage = 'message' in partial ? partial.message : base.message;
+                const nextNotice = 'notice' in partial ? partial.notice : base.notice;
+                const nextLauncher =
+                        preserveLauncher && !('launcher' in partial)
+                                ? base.launcher
+                                : 'launcher' in partial
+                                        ? partial.launcher
+                                        : base.launcher;
+
+                const next: UpdaterStatus = {
+                        state: nextState,
+                        progress: nextProgress,
+                        message: nextMessage,
+                        notice: nextNotice,
+                        launcher: nextLauncher
+                };
+
+                this.#applyStatus(next);
+        }
+
+        invalidate() {
+                this.#setStatus({
+                        state: 'needsValidation',
+                        progress: undefined,
+                        message: undefined
+                }, { preserveLauncher: true });
+        }
 
         async updateLauncher() {
                 if (os.platform() !== 'win32') return false;
@@ -335,8 +408,9 @@ class UpdaterClass extends Observable<UpdaterStatus> {
                 }
 
                 this.#setNotice(undefined);
+                this.#pendingLauncherUpdateRunner = null;
+                this.#launcherUpdateScheduled = false;
                 let updatePath: string | undefined;
-                let scriptPath: string | undefined;
                 let downloadPath: string | undefined;
                 let extractPath: string | undefined;
 
@@ -374,6 +448,19 @@ class UpdaterClass extends Observable<UpdaterStatus> {
                                 `New launcher version available (${versionText}). Downloading ${LAUNCHER_ARCHIVE_FILE}...`
                         );
 
+                        this.#setStatus(
+                                {
+                                        launcher: {
+                                                state: 'downloading',
+                                                progress: -1,
+                                                message: 'Preparing launcher update...'
+                                        },
+                                        progress: undefined,
+                                        message: undefined
+                                },
+                                { preserveLauncher: false }
+                        );
+
                         await fs.ensureDir(path.join(Preferences.userDataDir, 'downloads'));
                         downloadPath = path.join(
                                 Preferences.userDataDir,
@@ -385,10 +472,54 @@ class UpdaterClass extends Observable<UpdaterStatus> {
                         await resumableFetch(
                                 resolveLauncherUrl(LAUNCHER_ARCHIVE_FILE),
                                 downloadPath,
-                                undefined,
+                                progress => {
+                                        const totalBytes = progress.total + progress.initialPartial;
+                                        const downloaded = progress.done + progress.initialPartial;
+                                        const progressRatio =
+                                                totalBytes === 0 ? -1 : Math.min(downloaded / totalBytes, 1);
+                                        const percent =
+                                                totalBytes === 0
+                                                        ? 0
+                                                        : Math.round(Math.min(progressRatio, 1) * 100);
+                                        const elapsedSeconds = Math.max(
+                                                (Date.now() - progress.startedAt) / 1000,
+                                                0.001
+                                        );
+                                        const rate = progress.done / elapsedSeconds;
+                                        const remainingBytes = Math.max(totalBytes - downloaded, 0);
+                                        const eta =
+                                                rate === 0
+                                                        ? undefined
+                                                        : formatDuration(remainingBytes / rate);
+
+                                        this.#setStatus(
+                                                {
+                                                        launcher: {
+                                                                state: 'downloading',
+                                                                progress: progressRatio === -1 ? -1 : progressRatio,
+                                                                message:
+                                                                        eta && progressRatio !== -1
+                                                                                ? `Downloading launcher update... ${percent}% (${eta} remaining)`
+                                                                                : 'Downloading launcher update...'
+                                                        }
+                                                },
+                                                { preserveLauncher: false }
+                                        );
+                                },
                                 {
                                         throttle: 500
                                 }
+                        );
+
+                        this.#setStatus(
+                                {
+                                        launcher: {
+                                                state: 'downloading',
+                                                progress: -1,
+                                                message: 'Preparing launcher update...'
+                                        }
+                                },
+                                { preserveLauncher: false }
                         );
 
                         const execDir = process.env.PORTABLE_EXECUTABLE_DIR
@@ -426,46 +557,64 @@ class UpdaterClass extends Observable<UpdaterStatus> {
                         await fs.copy(extractedExecutablePath, updatePath, { overwrite: true });
 
                         const backupPath = path.join(execDir, `${execName}.old`);
-                        const escapedUpdatePath = escapeForBatch(updatePath);
-                        const escapedTargetPath = escapeForBatch(process.execPath);
-                        const escapedBackupPath = escapeForBatch(backupPath);
-                        scriptPath = path.join(execDir, 'update-launcher.bat');
-                        const processName = execName;
-                        const scriptContent = [
-                                '@echo off',
-                                'setlocal enableextensions',
-                                `set "SOURCE=${escapedUpdatePath}"`,
-                                `set "TARGET=${escapedTargetPath}"`,
-                                `set "BACKUP=${escapedBackupPath}"`,
-                                `set "PROCESS_NAME=${processName}"`,
-                                ':waitloop',
-                                'tasklist /FI "IMAGENAME eq %PROCESS_NAME%" | find /I "%PROCESS_NAME%" >NUL',
-                                'if %ERRORLEVEL%==0 (',
-                                '    timeout /t 1 >NUL',
-                                '    goto waitloop',
-                                ')',
-                                'if exist "%BACKUP%" del /f /q "%BACKUP%" >NUL 2>&1',
-                                'if exist "%TARGET%" move /Y "%TARGET%" "%BACKUP%" >NUL 2>&1',
-                                'move /Y "%SOURCE%" "%TARGET%" >NUL 2>&1',
-                                'start "" "%TARGET%"',
-                                'del "%~f0" >NUL 2>&1',
-                                'exit /b 0'
-                        ].join('\r\n');
-
-                        await fs.writeFile(scriptPath, scriptContent, 'utf8');
+                        const processName = path.parse(execName).name;
+                        const closeMessage =
+                                'Launcher update downloaded. Close the launcher to apply it.';
+                        const command = `
+$ErrorActionPreference = 'SilentlyContinue'
+$source = '${escapeForPowerShell(updatePath)}'
+$target = '${escapeForPowerShell(process.execPath)}'
+$backup = '${escapeForPowerShell(backupPath)}'
+$processName = '${escapeForPowerShell(processName)}'
+try {
+    while (Get-Process -Name $processName -ErrorAction SilentlyContinue) {
+        Start-Sleep -Milliseconds 250
+    }
+    if (Test-Path $backup) { Remove-Item -Path $backup -Force }
+    if (Test-Path $target) { Move-Item -Path $target -Destination $backup -Force }
+    Move-Item -Path $source -Destination $target -Force
+} catch {
+    if (Test-Path $source) { Copy-Item -Path $source -Destination $target -Force }
+}
+`;
+                        const encodedCommand = encodePowerShellCommand(command);
 
                         if (extractPath) {
                                 await fs.remove(extractPath);
                                 extractPath = undefined;
                         }
 
-                        spawn('cmd.exe', ['/c', 'start', '""', scriptPath], {
-                                detached: true,
-                                stdio: 'ignore'
-                        }).unref();
-
-                        Logger.log('Launcher update downloaded. Restarting to apply update.');
-                        app.quit();
+                        this.#pendingLauncherUpdateRunner = () => {
+                                spawn(
+                                        'powershell.exe',
+                                        [
+                                                '-NoLogo',
+                                                '-NoProfile',
+                                                '-WindowStyle',
+                                                'Hidden',
+                                                '-EncodedCommand',
+                                                encodedCommand
+                                        ],
+                                        {
+                                                detached: true,
+                                                stdio: 'ignore',
+                                                windowsHide: true
+                                        }
+                                ).unref();
+                        };
+                        this.#setStatus(
+                                {
+                                        launcher: {
+                                                state: 'pendingClose',
+                                                progress: 1,
+                                                message: closeMessage
+                                        },
+                                        progress: undefined,
+                                        message: undefined
+                                },
+                                { preserveLauncher: false }
+                        );
+                        Logger.log('Launcher update downloaded. Awaiting launcher closure to apply update.');
                         return true;
                 } catch (error) {
                         Logger.log('Failed to update launcher', 'error', error);
@@ -474,6 +623,15 @@ class UpdaterClass extends Observable<UpdaterStatus> {
                                         ? error.message
                                         : 'Unknown self-update error occurred';
                         this.#setNotice(`Self-update failed: ${message}`);
+                        this.#setStatus(
+                                {
+                                        state: 'needsValidation',
+                                        progress: undefined,
+                                        message: undefined,
+                                        launcher: undefined
+                                },
+                                { preserveLauncher: false }
+                        );
                         if (downloadPath) {
                                 try {
                                         await fs.remove(downloadPath);
@@ -496,17 +654,7 @@ class UpdaterClass extends Observable<UpdaterStatus> {
                                         );
                                 }
                         }
-                        if (scriptPath) {
-                                try {
-                                        await fs.remove(scriptPath);
-                                } catch (cleanupError) {
-                                        Logger.log(
-                                                'Failed to clean up launcher update script',
-                                                'error',
-                                                cleanupError
-                                        );
-                                }
-                        }
+                        this.#pendingLauncherUpdateRunner = null;
                         if (extractPath) {
                                 try {
                                         await fs.remove(extractPath);
@@ -533,38 +681,56 @@ class UpdaterClass extends Observable<UpdaterStatus> {
 			)
 				return;
 
-			if (!clientDir || !(await Preferences.isValidClientDir(clientDir))) {
-				this.status = { state: 'noClient' };
-				return;
-			}
+                        if (!clientDir || !(await Preferences.isValidClientDir(clientDir))) {
+                                this.#setStatus(
+                                        {
+                                                state: 'noClient',
+                                                progress: undefined,
+                                                message: undefined
+                                        },
+                                        { preserveLauncher: true }
+                                );
+                                return;
+                        }
 
                         if (isPortable) {
                                 await fs.remove(path.join(clientDir, 'update-script.bat'));
                         }
 
 			if (os.platform() === 'win32' && clientDir.length > 220) {
-				this.status = {
-					state: 'failed',
-					message:
-						'Path to current install location is too long and may cause issues.'
-				};
-				return;
-			}
+                                this.#setStatus(
+                                        {
+                                                state: 'failed',
+                                                progress: undefined,
+                                                message:
+                                                        'Path to current install location is too long and may cause issues.'
+                                        },
+                                        { preserveLauncher: true }
+                                );
+                                return;
+                        }
 
-			if (await isGameRunning()) {
-				this.status = {
-					state: 'failed',
-					message: 'Please close WoW first, before updating.'
-				};
-				return;
-			}
+                        if (await isGameRunning()) {
+                                this.#setStatus(
+                                        {
+                                                state: 'failed',
+                                                progress: undefined,
+                                                message: 'Please close WoW first, before updating.'
+                                        },
+                                        { preserveLauncher: true }
+                                );
+                                return;
+                        }
 
-			Logger.log(`Verifying client files at ${path.join(clientDir)}...`);
-                        this.status = {
-                                state: 'verifying',
-                                progress: 0,
-                                message: 'Looking for updates...'
-                        };
+                        Logger.log(`Verifying client files at ${path.join(clientDir)}...`);
+                        this.#setStatus(
+                                {
+                                        state: 'verifying',
+                                        progress: 0,
+                                        message: 'Looking for updates...'
+                                },
+                                { preserveLauncher: true }
+                        );
 
                         await this.#loadCache(clientDir);
                         let toDownload = 0;
@@ -580,11 +746,14 @@ class UpdaterClass extends Observable<UpdaterStatus> {
                                                 ? -1
                                                 : processedVerificationEntries / totalVerificationEntries;
                                 const displayName = meta.label ?? name;
-                                this.status = {
-                                        state: 'verifying',
-                                        progress: verificationProgress,
-                                        message: `Looking for updates... (${displayName})`
-                                };
+                                this.#setStatus(
+                                        {
+                                                state: 'verifying',
+                                                progress: verificationProgress,
+                                                message: `Looking for updates... (${displayName})`
+                                        },
+                                        { preserveLauncher: true }
+                                );
 
                                 const version = await fetchVersion(`${name}.version`);
 
@@ -825,64 +994,97 @@ class UpdaterClass extends Observable<UpdaterStatus> {
 
 			await this.#saveCache(clientDir);
 
-			if (toDownload !== 0) {
-				const availableSpace = await getAvailableDiskSpace(clientDir);
-				if (toDownload > availableSpace) {
-					this.status = {
-						state: 'failed',
-						message: `Not enough disk space. Required: ${formatFileSize(
-							toDownload
-						)}, Available: ${formatFileSize(availableSpace)}`
-					};
-					return;
-				}
-			}
+                        if (toDownload !== 0) {
+                                const availableSpace = await getAvailableDiskSpace(clientDir);
+                                if (toDownload > availableSpace) {
+                                        this.#setStatus(
+                                                {
+                                                        state: 'failed',
+                                                        progress: undefined,
+                                                        message: `Not enough disk space. Required: ${formatFileSize(
+                                                                toDownload
+                                                        )}, Available: ${formatFileSize(availableSpace)}`
+                                                },
+                                                { preserveLauncher: true }
+                                        );
+                                        return;
+                                }
+                        }
 
-			this.status =
-				toDownload !== 0
-					? { state: 'updateAvailable', message: formatFileSize(toDownload) }
-					: { state: 'upToDate', progress: 1 };
-		} catch (e) {
-			const message =
-				e instanceof Error ? e.message : 'Unexpected error occurred';
-			Logger.log(`Verification failed: ${message}`, 'error', e);
-			this.status = { state: 'failed', message };
-		}
+                        if (toDownload !== 0) {
+                                this.#setStatus(
+                                        {
+                                                state: 'updateAvailable',
+                                                progress: undefined,
+                                                message: formatFileSize(toDownload)
+                                        },
+                                        { preserveLauncher: true }
+                                );
+                        } else {
+                                this.#setStatus(
+                                        {
+                                                state: 'upToDate',
+                                                progress: 1,
+                                                message: undefined
+                                        },
+                                        { preserveLauncher: true }
+                                );
+                        }
+                } catch (e) {
+                        const message =
+                                e instanceof Error ? e.message : 'Unexpected error occurred';
+                        Logger.log(`Verification failed: ${message}`, 'error', e);
+                        this.#setStatus({ state: 'failed', message }, { preserveLauncher: true });
+                }
 	}
 
         async update(force?: boolean) {
                 const { clientDir, optionalPatches, selectedRealm } = Preferences.data;
                 const realmKey = selectedRealm ?? 'legionnaire';
-		try {
-			if (
+                try {
+                        if (
 				this.status?.state === 'verifying' ||
 				this.status?.state === 'updating'
 			)
 				return;
 
-			if (!clientDir || !(await Preferences.isValidClientDir(clientDir))) {
-				this.status = { state: 'noClient' };
-				return;
-			}
+                        if (!clientDir || !(await Preferences.isValidClientDir(clientDir))) {
+                                this.#setStatus(
+                                        {
+                                                state: 'noClient',
+                                                progress: undefined,
+                                                message: undefined
+                                        },
+                                        { preserveLauncher: true }
+                                );
+                                return;
+                        }
 
 			if (await isGameRunning()) {
-				this.status = {
-					state: 'failed',
-					message: 'Please close WoW first, before updating.'
-				};
-				return;
-			}
+                                this.#setStatus(
+                                        {
+                                                state: 'failed',
+                                                progress: undefined,
+                                                message: 'Please close WoW first, before updating.'
+                                        },
+                                        { preserveLauncher: true }
+                                );
+                                return;
+                        }
 
 			if (force) {
 				await fs.remove(path.join(Preferences.userDataDir, 'downloads'));
 			}
 
 			Logger.log(`Updating client files at ${path.join(clientDir)}...`);
-			this.status = {
-				state: 'updating',
-				progress: -1,
-				message: 'Preparing files...'
-			};
+                        this.#setStatus(
+                                {
+                                        state: 'updating',
+                                        progress: -1,
+                                        message: 'Preparing files...'
+                                },
+                                { preserveLauncher: true }
+                        );
 
                         for (const [name, meta] of Object.entries(FileMap)) {
                                 const isOptionalEnabled =
@@ -904,44 +1106,56 @@ class UpdaterClass extends Observable<UpdaterStatus> {
                                         continue;
 
 				Logger.log(`Downloading ${name} files...`);
-				const file = await fetchFile(`${name}.zip`, (p: FetchProgress) => {
-					const progress =
-						(p.done + p.initialPartial) / (p.total + p.initialPartial);
-					const percent = Math.round(progress * 100);
-					const elapsed = (Date.now() - p.startedAt) / 1000;
-					const rate = p.done / elapsed;
-					const eta = formatDuration(p.total / rate - elapsed);
-					this.status = {
-						state: 'updating',
-						progress,
-						message: `Downloading ${name}... ${percent}% (${eta} remaining)`
-					};
-				});
+                                const file = await fetchFile(`${name}.zip`, (p: FetchProgress) => {
+                                        const progress =
+                                                (p.done + p.initialPartial) / (p.total + p.initialPartial);
+                                        const percent = Math.round(progress * 100);
+                                        const elapsed = (Date.now() - p.startedAt) / 1000;
+                                        const rate = p.done / elapsed;
+                                        const eta = formatDuration(p.total / rate - elapsed);
+                                        this.#setStatus(
+                                                {
+                                                        state: 'updating',
+                                                        progress,
+                                                        message: `Downloading ${name}... ${percent}% (${eta} remaining)`
+                                                },
+                                                { preserveLauncher: true }
+                                        );
+                                });
 
-				this.status = {
-					state: 'updating',
-					progress: -1,
-					message: `Extracting ${name}...`
-				};
+                                this.#setStatus(
+                                        {
+                                                state: 'updating',
+                                                progress: -1,
+                                                message: `Extracting ${name}...`
+                                        },
+                                        { preserveLauncher: true }
+                                );
                                 const extractedFiles = await extractArchive(
                                         name,
                                         file,
                                         path.join(clientDir, meta.extractPath),
                                         (progress, percent) => {
                                                 if (progress === null) {
-                                                        this.status = {
-                                                                state: 'updating',
-                                                                progress: -1,
-                                                                message: `Extracting ${name}...`
-                                                        };
+                                                        this.#setStatus(
+                                                                {
+                                                                        state: 'updating',
+                                                                        progress: -1,
+                                                                        message: `Extracting ${name}...`
+                                                                },
+                                                                { preserveLauncher: true }
+                                                        );
                                                         return;
                                                 }
 
-                                                this.status = {
-                                                        state: 'updating',
-                                                        progress,
-                                                        message: `Extracting ${name}... ${percent}%`
-                                                };
+                                                this.#setStatus(
+                                                        {
+                                                                state: 'updating',
+                                                                progress,
+                                                                message: `Extracting ${name}... ${percent}%`
+                                                        },
+                                                        { preserveLauncher: true }
+                                                );
                                         }
                                 );
 
@@ -964,13 +1178,60 @@ class UpdaterClass extends Observable<UpdaterStatus> {
                                 await this.#saveCache(clientDir);
 			}
 
-			this.status = { state: 'upToDate', progress: 1 };
-		} catch (e) {
-			const message =
-				e instanceof Error ? e.message : 'Unexpected error occurred';
-			Logger.log(`Update failed: ${message}`, 'error', e);
-                        this.status = { state: 'failed', message };
+                        this.#setStatus(
+                                { state: 'upToDate', progress: 1 },
+                                { preserveLauncher: true }
+                        );
+                } catch (e) {
+                        const message =
+                                e instanceof Error ? e.message : 'Unexpected error occurred';
+                        Logger.log(`Update failed: ${message}`, 'error', e);
+                        this.#setStatus({ state: 'failed', message }, { preserveLauncher: true });
                 }
+        }
+
+        applyLauncherUpdate() {
+                if (!this.#pendingLauncherUpdateRunner) return false;
+                if (this.#launcherUpdateScheduled) return true;
+
+                this.#launcherUpdateScheduled = true;
+                this.#setStatus(
+                        {
+                                launcher: {
+                                        state: 'applying',
+                                        progress: -1,
+                                        message: 'Closing to apply launcher update...'
+                                }
+                        },
+                        { preserveLauncher: false }
+                );
+
+                this.#pendingLauncherUpdateRunner();
+                this.#pendingLauncherUpdateRunner = null;
+
+                app.quit();
+                return true;
+        }
+
+        handleLauncherBeforeQuit() {
+                if (!this.#pendingLauncherUpdateRunner) return;
+                if (this.#launcherUpdateScheduled) return;
+
+                this.#launcherUpdateScheduled = true;
+
+                this.#setStatus(
+                        {
+                                launcher: {
+                                        state: 'applying',
+                                        progress: -1,
+                                        message: 'Closing to apply launcher update...'
+                                }
+                        },
+                        { preserveLauncher: false }
+                );
+
+                this.#pendingLauncherUpdateRunner();
+                this.#pendingLauncherUpdateRunner = null;
         }
 
         async ensureRealmPatchesFor(realmKey: RealmId) {

--- a/src/renderer/components/LaunchPanel.tsx
+++ b/src/renderer/components/LaunchPanel.tsx
@@ -22,20 +22,20 @@ const LaunchPanel = () => {
 		UpdaterStatus['state'],
 		{ button: ReactElement; helperText?: ReactElement }
 	> = {
-		needsValidation: {
-			button: <Button onClick={() => verify.mutateAsync()}>Verify</Button>,
-			helperText: (
-				<div className="-mb-2">
+                needsValidation: {
+                        button: <Button onClick={() => verify.mutateAsync()}>Verify</Button>,
+                        helperText: (
+                                <div className="space-y-1">
 					<p>New changes detected</p>
 					<p className="text-xs text-textDark">Please verify your game data</p>
 				</div>
 			)
 		},
 		verifying: { button: <Button disabled>Verifying</Button> },
-		serverUnreachable: {
-			button: <Button onClick={() => verify.mutateAsync()}>Retry</Button>,
-			helperText: (
-				<div className="-mb-2">
+                serverUnreachable: {
+                        button: <Button onClick={() => verify.mutateAsync()}>Retry</Button>,
+                        helperText: (
+                                <div className="space-y-1">
 					<p>
 						<span className="text-secondary">Error: </span> Failed to reach
 						update server
@@ -44,8 +44,8 @@ const LaunchPanel = () => {
 				</div>
 			)
 		},
-		noClient: {
-			button: (
+                noClient: {
+                        button: (
 				<DialogButton
 					clickAway
 					dialog={close => <ClientDirDialog close={close} />}
@@ -57,8 +57,8 @@ const LaunchPanel = () => {
 					)}
 				</DialogButton>
 			),
-			helperText: (
-				<div className="-mb-2">
+                        helperText: (
+                                <div className="space-y-1">
 					<p>Client location was not yet selected</p>
 					<p className="text-xs text-textDark">
 						Please select your World of Warcraft 3.3.5 location
@@ -66,10 +66,10 @@ const LaunchPanel = () => {
 				</div>
 			)
 		},
-		updateAvailable: {
-			button: <Button onClick={() => update.mutateAsync()}>Update</Button>,
-			helperText: (
-				<div className="-mb-2">
+                updateAvailable: {
+                        button: <Button onClick={() => update.mutateAsync()}>Update</Button>,
+                        helperText: (
+                                <div className="space-y-1">
 					<p>Update available!</p>
 					<p className="text-xs text-textDark">
 						With total download size{' '}
@@ -79,22 +79,22 @@ const LaunchPanel = () => {
 			)
 		},
 		updating: { button: <Button disabled>Updating</Button> },
-		upToDate: {
-			button: (
+                upToDate: {
+                        button: (
 				<Button primary onClick={() => start.mutateAsync()}>
 					Play
 				</Button>
 			),
-			helperText: (
-				<div className="-mb-2">
+                        helperText: (
+                                <div className="space-y-1">
 					<p>Everything up to date!</p>
 				</div>
 			)
 		},
-		failed: {
-			button: <Button onClick={() => verify.mutateAsync()}>Retry</Button>,
-			helperText: (
-				<div className="-mb-2">
+                failed: {
+                        button: <Button onClick={() => verify.mutateAsync()}>Retry</Button>,
+                        helperText: (
+                                <div className="space-y-1">
 					<p>
 						<span className="text-secondary">Error: </span>
 						{status.message}
@@ -111,8 +111,8 @@ const LaunchPanel = () => {
 
         return (
                 <div className="flex gap-3">
-                        <div className="flex flex-grow select-none flex-col justify-end gap-3">
-                                <div className="-mb-2 flex flex-col gap-1">
+                        <div className="flex flex-grow select-none flex-col justify-end gap-2">
+                                <div className="flex flex-col gap-1 pb-1">
                                         {helper ??
                                                 (status.message && (
                                                         <p className="text-xs">{status.message}</p>

--- a/src/renderer/components/LaunchPanel.tsx
+++ b/src/renderer/components/LaunchPanel.tsx
@@ -107,14 +107,23 @@ const LaunchPanel = () => {
 		}
 	};
 
-	return (
-		<div className="flex gap-3">
-			<div className="flex flex-grow select-none flex-col justify-end gap-3">
-				{props[status.state].helperText ??
-					(status.message && <p className="-mb-2 text-xs">{status.message}</p>)}
-				<div className="loading-wrapper">
-					{status.progress !== undefined && (
-						<div
+        const helper = props[status.state].helperText;
+
+        return (
+                <div className="flex gap-3">
+                        <div className="flex flex-grow select-none flex-col justify-end gap-3">
+                                <div className="-mb-2 flex flex-col gap-1">
+                                        {helper ??
+                                                (status.message && (
+                                                        <p className="text-xs">{status.message}</p>
+                                                ))}
+                                        {status.notice && (
+                                                <p className="text-xs text-secondary">{status.notice}</p>
+                                        )}
+                                </div>
+                                <div className="loading-wrapper">
+                                        {status.progress !== undefined && (
+                                                <div
 							className={cls('loading', {
 								'loading-unknown': status.progress === -1
 							})}

--- a/src/renderer/components/LaunchPanel.tsx
+++ b/src/renderer/components/LaunchPanel.tsx
@@ -14,9 +14,10 @@ const LaunchPanel = () => {
 		onData: data => setStatus(data)
 	});
 
-	const verify = api.updater.verify.useMutation();
-	const update = api.updater.update.useMutation();
+        const verify = api.updater.verify.useMutation();
+        const update = api.updater.update.useMutation();
         const start = api.launcher.start.useMutation();
+        const closeLauncher = api.updater.closeLauncher.useMutation();
 
 	const props: Record<
 		UpdaterStatus['state'],
@@ -78,12 +79,12 @@ const LaunchPanel = () => {
 				</div>
 			)
 		},
-		updating: { button: <Button disabled>Updating</Button> },
+                updating: { button: <Button disabled>Updating</Button> },
                 upToDate: {
                         button: (
-				<Button primary onClick={() => start.mutateAsync()}>
-					Play
-				</Button>
+                                <Button primary onClick={() => start.mutateAsync()}>
+                                        Play
+                                </Button>
 			),
                         helperText: (
                                 <div className="space-y-1">
@@ -95,54 +96,105 @@ const LaunchPanel = () => {
                         button: <Button onClick={() => verify.mutateAsync()}>Retry</Button>,
                         helperText: (
                                 <div className="space-y-1">
-					<p>
-						<span className="text-secondary">Error: </span>
-						{status.message}
-					</p>
-					<p className="text-xs text-textDark">
-						Verify your game data by clicking Retry.
-					</p>
-				</div>
-			)
-		}
-	};
+                                        <p>
+                                                <span className="text-secondary">Error: </span>
+                                                {status.message}
+                                        </p>
+                                        <p className="text-xs text-textDark">
+                                                Verify your game data by clicking Retry.
+                                        </p>
+                                </div>
+                        )
+                }
+        };
 
-        const helper = props[status.state].helperText;
+        const base = props[status.state];
+        let helper = base.helperText;
+        let button = base.button;
+
+        const launcher = status.launcher;
+        if (launcher?.state === 'downloading') {
+                button = <Button disabled>Updating launcher</Button>;
+                helper = (
+                        <div className="space-y-1">
+                                <p>Launcher update in progress.</p>
+                                {launcher.message && (
+                                        <p className="text-xs text-textDark">{launcher.message}</p>
+                                )}
+                        </div>
+                );
+        } else if (launcher?.state === 'pendingClose') {
+                button = (
+                        <Button
+                                primary
+                                disabled={closeLauncher.isLoading}
+                                onClick={() => closeLauncher.mutateAsync()}
+                        >
+                                Close
+                        </Button>
+                );
+                helper = (
+                        <div className="space-y-1">
+                                <p>Launcher update downloaded.</p>
+                                <p className="text-xs text-textDark">
+                                        {launcher.message ?? 'Please close the launcher to finish updating.'}
+                                </p>
+                        </div>
+                );
+        } else if (launcher?.state === 'applying') {
+                button = <Button disabled>Closing...</Button>;
+                helper = (
+                        <div className="space-y-1">
+                                <p>Closing to apply launcher update...</p>
+                        </div>
+                );
+        }
+
+        const progressValue =
+                launcher?.state === 'downloading'
+                        ? launcher.progress
+                        : launcher?.state === 'pendingClose'
+                                ? 1
+                                : launcher?.state === 'applying'
+                                        ? -1
+                                        : status.progress;
+
+        const progressMessage = launcher?.message ?? status.message;
 
         return (
                 <div className="flex gap-3">
                         <div className="flex flex-grow select-none flex-col justify-end gap-2">
                                 <div className="flex flex-col gap-1 pb-1">
                                         {helper ??
-                                                (status.message && (
-                                                        <p className="text-xs">{status.message}</p>
+                                                (progressMessage && (
+                                                        <p className="text-xs">{progressMessage}</p>
                                                 ))}
                                         {status.notice && (
                                                 <p className="text-xs text-secondary">{status.notice}</p>
                                         )}
                                 </div>
                                 <div className="loading-wrapper">
-                                        {status.progress !== undefined && (
+                                        {progressValue !== undefined && (
                                                 <div
-							className={cls('loading', {
-								'loading-unknown': status.progress === -1
-							})}
-							style={
-								status.progress !== -1
-									? {
-											clipPath: `inset(0 ${
-												100 - Math.ceil(Math.abs(status.progress) * 100)
-											}% 0 0)`
-									  }
-									: undefined
-							}
-						/>
-					)}
-				</div>
-			</div>
-			{props[status.state].button}
-		</div>
-	);
+                                                        className={cls('loading', {
+                                                                'loading-unknown': progressValue === -1
+                                                        })}
+                                                        style={
+                                                                progressValue !== -1
+                                                                        ? {
+                                                                                        clipPath: `inset(0 ${
+                                                                                                100 - Math.ceil(Math.abs(progressValue) * 100)
+                                                                                        }% 0 0)`
+                                                                          }
+                                                                        : undefined
+                                                        }
+                                                />
+                                        )}
+                                </div>
+                        </div>
+                        {button}
+                </div>
+        );
 };
 
 export default LaunchPanel;

--- a/src/renderer/components/RealmSwitch.tsx
+++ b/src/renderer/components/RealmSwitch.tsx
@@ -12,7 +12,13 @@ const RealmSwitch = () => {
         const [isLoading, setIsLoading] = useState(false);
         api.updater.observe.useSubscription(undefined, {
                 onData: data =>
-                        setIsLoading(data.state === 'verifying' || data.state === 'updating')
+                        setIsLoading(
+                                data.state === 'verifying' ||
+                                        data.state === 'updating' ||
+                                        data.launcher?.state === 'downloading' ||
+                                        data.launcher?.state === 'pendingClose' ||
+                                        data.launcher?.state === 'applying'
+                        )
         });
 
         const onSelect = async (realm: RealmId) => {


### PR DESCRIPTION
## Summary
- add a hidden PowerShell handoff for applying launcher updates so closing the app replaces the executable without flashing a batch window
- avoid duplicating the close-to-update notice while keeping the existing progress helper message
- set a dark BrowserWindow background color so the launcher no longer flashes white while loading

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_69029922462483279176d0e62a49d4fe