### PR TITLE
Handle update server timeouts

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -102,6 +102,7 @@ export const FileMap: Record<
         ['patch-enUS-8']: { extractPath: 'Data/enUS', realms: ['legionnaire_plus'] },
         ['patch-enUS-9']: { extractPath: 'Data/enUS', realms: ['barracks', 'barracks_plus'] },
         ['patch-enUS-10']: { extractPath: 'Data/enUS', realms: ['barracks_plus'] },
+        ['patch-dungeon-maps']: { extractPath: 'Data', realms: ['barracks', 'townsendboys'] },
         ['hd-creatures']: {
                 extractPath: 'Data',
                 optional: true,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -71,6 +71,9 @@ const createWindow = async () => {
 app.whenReady().then(async () => {
         // Initialization
         Preferences.data = await Preferences.load();
+
+        await createWindow();
+
         const launcherUpdateTriggered = await Updater.updateLauncher();
         if (launcherUpdateTriggered) return;
         Updater.verify();
@@ -85,7 +88,6 @@ app.whenReady().then(async () => {
 		optimizer.watchWindowShortcuts(window);
 	});
 
-	await createWindow();
 });
 
 // Quit when all windows are closed

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -37,12 +37,19 @@ const createWindow = async () => {
 
 	createIPCHandler({ router: appRouter, windows: [mainWindow] });
 
-	mainWindow.on('ready-to-show', () => {
-		// Clean up all observers
-		Updater.clearObservers();
+        mainWindow.on('ready-to-show', () => {
+                // Clean up all observers
+                Updater.clearObservers();
 
-		mainWindow?.show();
-	});
+                mainWindow?.show();
+        });
+
+        mainWindow.webContents.once('did-finish-load', async () => {
+                const launcherUpdateTriggered = await Updater.updateLauncher();
+                if (launcherUpdateTriggered) return;
+
+                Updater.verify();
+        });
 
 	mainWindow.webContents.setWindowOpenHandler(details => {
 		shell.openExternal(details.url);
@@ -71,9 +78,8 @@ const createWindow = async () => {
 app.whenReady().then(async () => {
         // Initialization
         Preferences.data = await Preferences.load();
-        const launcherUpdateTriggered = await Updater.updateLauncher();
-        if (launcherUpdateTriggered) return;
-        Updater.verify();
+
+        await createWindow();
 
 	// Set app user model id for windows
 	electronApp.setAppUserModelId('com.electron');
@@ -85,7 +91,6 @@ app.whenReady().then(async () => {
 		optimizer.watchWindowShortcuts(window);
 	});
 
-	await createWindow();
 });
 
 // Quit when all windows are closed

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -69,9 +69,11 @@ const createWindow = async () => {
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
 app.whenReady().then(async () => {
-	// Initialization
-	Preferences.data = await Preferences.load();
-	Updater.verify();
+        // Initialization
+        Preferences.data = await Preferences.load();
+        const launcherUpdateTriggered = await Updater.updateLauncher();
+        if (launcherUpdateTriggered) return;
+        Updater.verify();
 
 	// Set app user model id for windows
 	electronApp.setAppUserModelId('com.electron');

--- a/src/main/modules/updater.ts
+++ b/src/main/modules/updater.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 import { exec, spawn } from 'node:child_process';
 import os from 'node:os';
 
-import fetch from 'node-fetch';
+import fetch, { FetchError, type RequestInit } from 'node-fetch';
 import fs from 'fs-extra';
 import yauzl from 'yauzl-promise';
 
@@ -27,6 +27,52 @@ const resolvePatchUrl = (filePath: string) =>
 
 const resolveLauncherUrl = (filePath: string) =>
         new URL(filePath.replace(/^\/+/, ''), resolveBaseUrl()).toString();
+
+const REQUEST_TIMEOUT = 15_000;
+
+const fetchWithTimeout = async (url: string, options: RequestInit = {}) => {
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT);
+        try {
+                const response = await fetch(url, {
+                        ...options,
+                        signal: controller.signal
+                });
+                return response;
+        } catch (error) {
+                if (error instanceof Error && error.name === 'AbortError') {
+                        const timeoutError = new Error('Request to update server timed out');
+                        timeoutError.name = 'AbortError';
+                        throw timeoutError;
+                }
+                throw error;
+        } finally {
+                clearTimeout(timeout);
+        }
+};
+
+const isNetworkError = (error: unknown) => {
+        if (error instanceof FetchError) {
+                return true;
+        }
+
+        if (error instanceof Error) {
+                if (error.name === 'AbortError') return true;
+
+                const code = (error as NodeJS.ErrnoException).code;
+                if (
+                        code === 'ENOTFOUND' ||
+                        code === 'ECONNRESET' ||
+                        code === 'ECONNREFUSED' ||
+                        code === 'EAI_AGAIN' ||
+                        code === 'ETIMEDOUT'
+                ) {
+                        return true;
+                }
+        }
+
+        return false;
+};
 
 // const isReadOnly = async (filePath: string) => {
 // 	try {
@@ -99,20 +145,26 @@ const fetchFile = async (
 };
 
 const fetchSize = async (filePath: string) => {
-	try {
-                const response = await fetch(resolvePatchUrl(filePath), {
+        try {
+                const response = await fetchWithTimeout(resolvePatchUrl(filePath), {
                         method: 'HEAD'
                 });
-		return parseInt(response.headers.get('content-length') ?? '0');
-	} catch (e) {
-		Logger.log(`Failed to download ${filePath}`, 'error', e);
-		throw Error(`Failed to download ${filePath}`);
-	}
+                if (!response.ok) {
+                        throw new Error(`Failed to fetch size for ${filePath}`);
+                }
+                return parseInt(response.headers.get('content-length') ?? '0');
+        } catch (e) {
+                Logger.log(`Failed to download ${filePath}`, 'error', e);
+                throw Error(`Failed to download ${filePath}`);
+        }
 };
 
 const fetchVersion = async (filePath: string) => {
         try {
-                const response = await fetch(resolvePatchUrl(filePath));
+                const response = await fetchWithTimeout(resolvePatchUrl(filePath));
+                if (!response.ok) {
+                        throw new Error(`Failed to fetch version for ${filePath}`);
+                }
                 return response.text();
         } catch (e) {
                 Logger.log(`Failed to download ${filePath}`, 'error', e);
@@ -337,7 +389,7 @@ class UpdaterClass extends Observable<UpdaterStatus> {
                 let downloadPath: string | undefined;
 
                 try {
-                        const manifestResponse = await fetch(
+                        const manifestResponse = await fetchWithTimeout(
                                 resolveLauncherUrl('latest.yaml')
                         );
 
@@ -780,12 +832,25 @@ class UpdaterClass extends Observable<UpdaterStatus> {
 				toDownload !== 0
 					? { state: 'updateAvailable', message: formatFileSize(toDownload) }
 					: { state: 'upToDate', progress: 1 };
-		} catch (e) {
-			const message =
-				e instanceof Error ? e.message : 'Unexpected error occurred';
-			Logger.log(`Verification failed: ${message}`, 'error', e);
-			this.status = { state: 'failed', message };
-		}
+                } catch (e) {
+                        if (isNetworkError(e)) {
+                                Logger.log(
+                                        'Verification failed: update server unreachable',
+                                        'error',
+                                        e
+                                );
+                                this.status = {
+                                        state: 'serverUnreachable',
+                                        message: 'Failed to reach update server. Please try again later.'
+                                };
+                                return;
+                        }
+
+                        const message =
+                                e instanceof Error ? e.message : 'Unexpected error occurred';
+                        Logger.log(`Verification failed: ${message}`, 'error', e);
+                        this.status = { state: 'failed', message };
+                }
 	}
 
         async update(force?: boolean) {
@@ -903,10 +968,23 @@ class UpdaterClass extends Observable<UpdaterStatus> {
 			}
 
 			this.status = { state: 'upToDate', progress: 1 };
-		} catch (e) {
-			const message =
-				e instanceof Error ? e.message : 'Unexpected error occurred';
-			Logger.log(`Update failed: ${message}`, 'error', e);
+                } catch (e) {
+                        if (isNetworkError(e)) {
+                                Logger.log(
+                                        'Update failed: update server unreachable',
+                                        'error',
+                                        e
+                                );
+                                this.status = {
+                                        state: 'serverUnreachable',
+                                        message: 'Failed to reach update server. Please try again later.'
+                                };
+                                return;
+                        }
+
+                        const message =
+                                e instanceof Error ? e.message : 'Unexpected error occurred';
+                        Logger.log(`Update failed: ${message}`, 'error', e);
                         this.status = { state: 'failed', message };
                 }
         }

--- a/src/main/modules/updater.ts
+++ b/src/main/modules/updater.ts
@@ -1,10 +1,12 @@
 import path from 'node:path';
-import { exec } from 'node:child_process';
+import { exec, spawn } from 'node:child_process';
 import os from 'node:os';
 
 import fetch from 'node-fetch';
 import fs from 'fs-extra';
 import yauzl from 'yauzl-promise';
+
+import { app } from 'electron';
 
 import { mainWindow } from '~main/index';
 import { formatDuration, formatFileSize } from '~common/utils';
@@ -22,6 +24,9 @@ const resolveBaseUrl = () => {
 
 const resolvePatchUrl = (filePath: string) =>
         new URL(`patches/${filePath.replace(/^\/+/, '')}`, resolveBaseUrl()).toString();
+
+const resolveLauncherUrl = (filePath: string) =>
+        new URL(filePath.replace(/^\/+/, ''), resolveBaseUrl()).toString();
 
 // const isReadOnly = async (filePath: string) => {
 // 	try {
@@ -114,6 +119,40 @@ const fetchVersion = async (filePath: string) => {
                 throw Error(`Failed to download ${filePath}`);
         }
 };
+
+const compareVersions = (a: string, b: string) => {
+        const parse = (version: string) =>
+                version
+                        .split(/[^0-9]+/)
+                        .filter(Boolean)
+                        .map(part => Number.parseInt(part, 10));
+
+        const left = parse(a);
+        const right = parse(b);
+        const length = Math.max(left.length, right.length);
+
+        for (let i = 0; i < length; i += 1) {
+                const leftPart = left[i] ?? 0;
+                const rightPart = right[i] ?? 0;
+                if (leftPart > rightPart) return 1;
+                if (leftPart < rightPart) return -1;
+        }
+
+        return 0;
+};
+
+const parseLauncherManifest = (manifest: string) => {
+        const versionMatch = manifest.match(/^version:\s*([^\s]+)\s*$/m);
+        if (!versionMatch) return undefined;
+
+        const fileMatch = manifest.match(/^-\s+url:\s*(\S+)\s*$/m);
+        return {
+                version: versionMatch[1].trim(),
+                file: fileMatch?.[1]?.trim()
+        };
+};
+
+const escapeForBatch = (value: string) => value.replace(/\\/g, '\\\\');
 
 type ExtractProgressCallback = (progress: number | null, percent?: number) => void;
 
@@ -287,11 +326,138 @@ class UpdaterClass extends Observable<UpdaterStatus> {
 	}
 
         async updateLauncher() {
-                Logger.log('Launcher updates are currently disabled.');
-                this.status = {
-                        state: 'failed',
-                        message: 'Launcher updates are currently disabled. Please download the latest release manually.'
-                };
+                if (os.platform() !== 'win32') return false;
+                if (!app.isPackaged) {
+                        Logger.log('Skipping launcher update in development environment.');
+                        return false;
+                }
+
+                let updatePath: string | undefined;
+                let scriptPath: string | undefined;
+                let downloadPath: string | undefined;
+
+                try {
+                        const manifestResponse = await fetch(
+                                resolveLauncherUrl('latest.yaml')
+                        );
+
+                        if (!manifestResponse.ok) {
+                                Logger.log('Failed to fetch launcher manifest. Skipping update.');
+                                return false;
+                        }
+
+                        const manifest = parseLauncherManifest(await manifestResponse.text());
+                        if (!manifest) {
+                                Logger.log('Launcher manifest is invalid. Skipping update.');
+                                return false;
+                        }
+
+                        const currentVersion = app.getVersion();
+                        if (compareVersions(manifest.version, currentVersion) <= 0) {
+                                Logger.log('Launcher is up to date.');
+                                return false;
+                        }
+
+                        const fileName = manifest.file ?? path.basename(process.execPath);
+                        Logger.log(
+                                `New launcher version available (${manifest.version}). Downloading ${fileName}...`
+                        );
+
+                        await fs.ensureDir(path.join(Preferences.userDataDir, 'downloads'));
+                        downloadPath = path.join(
+                                Preferences.userDataDir,
+                                'downloads',
+                                fileName
+                        );
+                        await fs.ensureDir(path.dirname(downloadPath));
+
+                        await resumableFetch(resolveLauncherUrl(fileName), downloadPath, undefined, {
+                                throttle: 500
+                        });
+
+                        const execDir = process.env.PORTABLE_EXECUTABLE_DIR
+                                ? process.env.PORTABLE_EXECUTABLE_DIR
+                                : path.dirname(process.execPath);
+                        const execName = path.basename(process.execPath);
+                        updatePath = path.join(execDir, `${execName}.update`);
+                        await fs.copy(downloadPath, updatePath, { overwrite: true });
+                        await fs.remove(downloadPath);
+                        downloadPath = undefined;
+
+                        const backupPath = path.join(execDir, `${execName}.old`);
+                        const escapedUpdatePath = escapeForBatch(updatePath);
+                        const escapedTargetPath = escapeForBatch(process.execPath);
+                        const escapedBackupPath = escapeForBatch(backupPath);
+                        scriptPath = path.join(execDir, 'update-launcher.bat');
+                        const processName = execName;
+                        const scriptContent = [
+                                '@echo off',
+                                'setlocal enableextensions',
+                                `set "SOURCE=${escapedUpdatePath}"`,
+                                `set "TARGET=${escapedTargetPath}"`,
+                                `set "BACKUP=${escapedBackupPath}"`,
+                                `set "PROCESS_NAME=${processName}"`,
+                                ':waitloop',
+                                'tasklist /FI "IMAGENAME eq %PROCESS_NAME%" | find /I "%PROCESS_NAME%" >NUL',
+                                'if %ERRORLEVEL%==0 (',
+                                '    timeout /t 1 >NUL',
+                                '    goto waitloop',
+                                ')',
+                                'if exist "%BACKUP%" del /f /q "%BACKUP%" >NUL 2>&1',
+                                'if exist "%TARGET%" move /Y "%TARGET%" "%BACKUP%" >NUL 2>&1',
+                                'move /Y "%SOURCE%" "%TARGET%" >NUL 2>&1',
+                                'start "" "%TARGET%"',
+                                'del "%~f0" >NUL 2>&1',
+                                'exit /b 0'
+                        ].join('\r\n');
+
+                        await fs.writeFile(scriptPath, scriptContent, 'utf8');
+
+                        spawn('cmd.exe', ['/c', 'start', '""', scriptPath], {
+                                detached: true,
+                                stdio: 'ignore'
+                        }).unref();
+
+                        Logger.log('Launcher update downloaded. Restarting to apply update.');
+                        app.quit();
+                        return true;
+                } catch (error) {
+                        Logger.log('Failed to update launcher', 'error', error);
+                        if (downloadPath) {
+                                try {
+                                        await fs.remove(downloadPath);
+                                } catch (cleanupError) {
+                                        Logger.log(
+                                                'Failed to clean up launcher download',
+                                                'error',
+                                                cleanupError
+                                        );
+                                }
+                        }
+                        if (updatePath) {
+                                try {
+                                        await fs.remove(updatePath);
+                                } catch (cleanupError) {
+                                        Logger.log(
+                                                'Failed to clean up launcher update file',
+                                                'error',
+                                                cleanupError
+                                        );
+                                }
+                        }
+                        if (scriptPath) {
+                                try {
+                                        await fs.remove(scriptPath);
+                                } catch (cleanupError) {
+                                        Logger.log(
+                                                'Failed to clean up launcher update script',
+                                                'error',
+                                                cleanupError
+                                        );
+                                }
+                        }
+                        return false;
+                }
         }
 
 	async verify() {


### PR DESCRIPTION
## Summary
- add shared timeout-aware fetch helper for launcher update requests
- detect and surface network failures as a dedicated `serverUnreachable` status
- ensure verification and update flows bail quickly when the update server cannot be reached

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_6903e597db208327b252626bd05ccd54