### PR TITLE
Simplify UI to blank settings screen

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,47 +1,10 @@
-import { api } from './utils/api';
-import WoWLogo from './assets/logo.png';
-import LaunchPanel from './components/LaunchPanel';
 import TopBar from './components/TopBar';
-import IconSpinner from './components/styled/IconSpinner';
-import RealmSwitch from './components/RealmSwitch';
-import OptionalPatches from './components/OptionalPatches';
 
-const App = () => {
-	const { isLoading } = api.preferences.get.useQuery();
-	const version = api.general.version.useQuery();
-
-	return (
-		<div className="relative flex grow flex-col gap-3 overflow-hidden border border-textDark/10 bg-dark bg-cover bg-top bg-no-repeat p-[44px]">
-			<TopBar />
-
-			{isLoading ? (
-				<div className="flex flex-grow items-center justify-center">
-					<IconSpinner />
-				</div>
-			) : (
-				<>
-					<div className="flex select-none items-center gap-4 self-start">
-						<img src={WoWLogo} alt="Logo" className="shrink-0" />
-                                                <h1 className="uppercase">
-                                                        <p className="text-2xl">Centurion</p>
-                                                </h1>
-					</div>
-
-					<div className="flex min-h-0 flex-grow select-none flex-col items-center gap-2">
-						<RealmSwitch />
-						<OptionalPatches />
-					</div>
-					<LaunchPanel />
-				</>
-			)}
-
-			{!version.isLoading && (
-				<p className="absolute bottom-2 right-2 text-xs text-textDark">
-					v{version.data}
-				</p>
-			)}
-		</div>
-	);
-};
+const App = () => (
+        <div className="flex h-full min-h-screen flex-col bg-black text-white">
+                <TopBar />
+                <div className="flex flex-1" />
+        </div>
+);
 
 export default App;

--- a/src/renderer/components/TopBar.tsx
+++ b/src/renderer/components/TopBar.tsx
@@ -1,102 +1,11 @@
-import { Menu, Minus, X } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { Menu } from 'lucide-react';
 
-import { api } from '~renderer/utils/api';
-
-import DialogButton from './styled/DialogButton';
 import TextButton from './styled/TextButton';
-import PreferencesDialog from './PreferencesDialog';
 
-const TopBar = () => {
-	const [safeToQuit, setSafeToQuit] = useState(true);
-	api.updater.observe.useSubscription(undefined, {
-		onData: ({ state }) =>
-			setSafeToQuit(state !== 'verifying' && state !== 'updating')
-	});
-
-	// Window drag
-	const [dragging, setDragging] = useState(false);
-	const dragWindow = api.general.dragWindow.useMutation();
-
-	useEffect(() => {
-		const dragCallback = (e: MouseEvent) => {
-			dragging && dragWindow.mutate({ x: e.movementX, y: e.movementY });
-		};
-		const endCallback = (e: MouseEvent) => {
-			dragging && e.buttons === 0 && setDragging(false);
-		};
-		window.addEventListener('mousemove', dragCallback);
-		window.addEventListener('mouseup', endCallback);
-		return () => {
-			window.removeEventListener('mousemove', dragCallback);
-			window.removeEventListener('mouseup', endCallback);
-		};
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [dragWindow]);
-
-	const minimize = api.general.minimize.useMutation();
-	const quit = api.general.quit.useMutation();
-	return (
-		// eslint-disable-next-line jsx-a11y/no-static-element-interactions
-		<div
-			onMouseDown={e =>
-				e.target === e.currentTarget && e.buttons === 1 && setDragging(true)
-			}
-			className="absolute left-0 right-0 top-0 flex justify-end pr-2 pt-2 opacity-50"
-		>
-			<DialogButton
-				clickAway
-				dialog={close => <PreferencesDialog close={close} />}
-			>
-				{open => (
-					<TextButton
-						icon={Menu}
-						title="Settings"
-						onClick={open}
-						size={16}
-						className="!p-1"
-					/>
-				)}
-			</DialogButton>
-			<TextButton
-				icon={Minus}
-				title="Minimize"
-				onClick={() => minimize.mutateAsync()}
-				size={20}
-				className="!p-1"
-			/>
-			<DialogButton
-				dialog={close => (
-					<div className="dialog">
-						<h2 className="color mb-2 text-xl">Quit?</h2>
-						<p>
-							Your game is currently being updated. Quitting now may cause
-							problems.
-						</p>
-						<div className="flex gap-2 self-end">
-							<TextButton onClick={close}>Return</TextButton>
-							<TextButton
-								onClick={() => quit.mutateAsync()}
-								className="text-secondary"
-							>
-								Quit
-							</TextButton>
-						</div>
-					</div>
-				)}
-			>
-				{open => (
-					<TextButton
-						icon={X}
-						title="Quit"
-						onClick={() => (!safeToQuit ? open() : quit.mutateAsync())}
-						size={20}
-						className="!p-1 hocus:text-secondary"
-					/>
-				)}
-			</DialogButton>
-		</div>
-	);
-};
+const TopBar = () => (
+        <div className="flex justify-end p-4">
+                <TextButton icon={Menu} title="Settings" onClick={() => undefined} className="!p-1" />
+        </div>
+);
 
 export default TopBar;

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -4,7 +4,6 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { loggerLink } from '@trpc/client';
 import { ipcLink } from 'electron-trpc/renderer';
 import superjson from 'superjson';
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { getQueryKey } from '@trpc/react-query';
 
 import { api } from './utils/api';
@@ -53,12 +52,11 @@ const trpcClient = api.createClient({
 });
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
-	<StrictMode>
-		<api.Provider client={trpcClient} queryClient={queryClient}>
-			<QueryClientProvider client={queryClient}>
-				<App />
-				<ReactQueryDevtools />
-			</QueryClientProvider>
-		</api.Provider>
-	</StrictMode>
+        <StrictMode>
+                <api.Provider client={trpcClient} queryClient={queryClient}>
+                        <QueryClientProvider client={queryClient}>
+                                <App />
+                        </QueryClientProvider>
+                </api.Provider>
+        </StrictMode>
 );


### PR DESCRIPTION
## Summary
- replace the renderer layout with a blank black screen that only shows the top settings button
- simplify the top bar to a no-op settings button and remove other controls

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69398018e1408327a7f34fbf9b942a2d)