### PR TITLE
Map Barracks+ to patch-enUS-A and remove patch-enUS-9 association

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -100,8 +100,8 @@ export const FileMap: Record<
                 realms: ['legionnaire', 'legionnaire_plus', 'barracks', 'barracks_plus']
         },
         ['patch-enUS-8']: { extractPath: 'Data/enUS', realms: ['legionnaire_plus'] },
-        ['patch-enUS-9']: { extractPath: 'Data/enUS', realms: ['barracks', 'barracks_plus'] },
-        ['patch-enUS-10']: { extractPath: 'Data/enUS', realms: ['barracks_plus'] },
+        ['patch-enUS-9']: { extractPath: 'Data/enUS', realms: ['barracks'] },
+        ['patch-enUS-A']: { extractPath: 'Data/enUS', realms: ['barracks_plus'] },
         ['patch-dungeon-maps']: { extractPath: 'Data', realms: ['barracks', 'townsendboys'] },
         ['hd-creatures']: {
                 extractPath: 'Data',


### PR DESCRIPTION
### Motivation
- Align Barracks+ file mapping to use `patch-enUS-A` instead of `patch-enUS-10` and stop including Barracks+ in `patch-enUS-9` so patch-to-realm mappings match the intended distribution.

### Description
- Modify `src/common/constants.ts` to replace the `patch-enUS-10` entry with `patch-enUS-A` for `barracks_plus` and remove `barracks_plus` from the `patch-enUS-9` realms so `patch-enUS-9` applies only to `barracks`.

### Testing
- Ran `git diff --check` and `npm run build`, both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a287bc669908327aca6dc76d2a6cb93)