### PR TITLE
Add Barracks+ to non-dev server selector

### DIFF
--- a/src/renderer/components/RealmSwitch.tsx
+++ b/src/renderer/components/RealmSwitch.tsx
@@ -30,7 +30,10 @@ const RealmSwitch = () => {
 
         const availableRealmEntries: [RealmId, (typeof REALMS)[RealmId]][] = pref?.isDev
                 ? (Object.entries(REALMS) as [RealmId, (typeof REALMS)[RealmId]][])
-                : [['legionnaire_plus', REALMS.legionnaire_plus]];
+                : [
+                          ['legionnaire_plus', REALMS.legionnaire_plus],
+                          ['barracks_plus', REALMS.barracks_plus]
+                  ];
 
         const selectedRealm =
                 pref?.selectedRealm &&


### PR DESCRIPTION
### Motivation
- Allow non-dev users to choose the Barracks+ realm from the server dropdown since only `legionnaire_plus` was previously exposed to non-dev users.

### Description
- Modify `src/renderer/components/RealmSwitch.tsx` to add `['barracks_plus', REALMS.barracks_plus]` to the non-dev `availableRealmEntries` fallback alongside `['legionnaire_plus', REALMS.legionnaire_plus]`.

### Testing
- Ran `npm run build:test` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d908953e08327bcbab8a40df91114)