### PR TITLE
Add FileMap entry for `patch-Z`

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -102,6 +102,7 @@ export const FileMap: Record<
         ['patch-enUS-8']: { extractPath: 'Data/enUS', realms: ['legionnaire_plus'] },
         ['patch-enUS-9']: { extractPath: 'Data/enUS', realms: ['barracks'] },
         ['patch-enUS-A']: { extractPath: 'Data/enUS', realms: ['barracks_plus'] },
+        ['patch-Z']: { extractPath: 'Data' },
         ['patch-dungeon-maps']: { extractPath: 'Data', realms: ['barracks', 'townsendboys'] },
         ['hd-creatures']: {
                 extractPath: 'Data',


### PR DESCRIPTION
### Motivation
- Add a missing file mapping so the `patch-Z` archive is recognized and its contents are extracted into the `Data` folder.

### Description
- Inserted a `FileMap` entry `['patch-Z']` mapping to `{ extractPath: 'Data' }` in `src/common/constants.ts`.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2dba318e148327b3a6020cecf05fda)