### PR TITLE
Preserve public realm selection for non-dev users

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -3,135 +3,143 @@ export const DEFAULT_REALMLIST = '136.56.187.218';
 export const DEFAULT_AZEROTHCORE_REALMLIST = '136.56.187.218:3726';
 
 export const REALM_IDS = [
-        'legionnaire_plus',
-        'legionnaire',
-        'barracks',
-        'barracks_plus',
-        'trinityworld',
-        'townsendboys'
+	'legionnaire_plus',
+	'legionnaire',
+	'barracks',
+	'barracks_plus',
+	'trinityworld',
+	'townsendboys'
 ] as const;
 export type RealmId = (typeof REALM_IDS)[number];
 
+export const PUBLIC_REALM_IDS = [
+	'legionnaire_plus',
+	'barracks_plus'
+] as const satisfies readonly RealmId[];
+
 type BuildInfo = {
-        string: string;
-        number: number;
+	string: string;
+	number: number;
 };
 
 const BUILD_12340: BuildInfo = {
-        string: '12340',
-        number: 12340
+	string: '12340',
+	number: 12340
 };
 
 const BUILD_12341: BuildInfo = {
-        string: '12341',
-        number: 12341
+	string: '12341',
+	number: 12341
 };
 
 const BUILD_12342: BuildInfo = {
-        string: '12342',
-        number: 12342
+	string: '12342',
+	number: 12342
 };
 
 export const REALMS: Record<
-        RealmId,
-        {
-                label: string;
-                realmName: string;
-                build: BuildInfo;
-                realmlistType: 'trinitycore' | 'azerothcore';
-        }
+	RealmId,
+	{
+		label: string;
+		realmName: string;
+		build: BuildInfo;
+		realmlistType: 'trinitycore' | 'azerothcore';
+	}
 > = {
-        legionnaire_plus: {
-                label: 'Legionnaire+',
-                realmName: 'Legionnaire Plus',
-                build: BUILD_12341,
-                realmlistType: 'trinitycore'
-        },
-        legionnaire: {
-                label: 'Legionnaire',
-                realmName: 'Legionnaire',
-                build: BUILD_12340,
-                realmlistType: 'trinitycore'
-        },
-        barracks: {
-                label: 'Barracks',
-                realmName: 'Barracks',
-                build: BUILD_12342,
-                realmlistType: 'trinitycore'
-        },
-        barracks_plus: {
-                label: 'Barracks+',
-                realmName: 'Barracks Plus',
-                build: BUILD_12342,
-                realmlistType: 'trinitycore'
-        },
-        trinityworld: {
-                label: 'TRINITYWORLD',
-                realmName: 'TRINITYWORLD',
-                build: BUILD_12340,
-                realmlistType: 'trinitycore'
-        },
-        townsendboys: {
-                label: 'TOWNSENDBOYS',
-                realmName: 'TOWNSENDBOYS',
-                build: BUILD_12340,
-                realmlistType: 'azerothcore'
-        }
+	legionnaire_plus: {
+		label: 'Legionnaire+',
+		realmName: 'Legionnaire Plus',
+		build: BUILD_12341,
+		realmlistType: 'trinitycore'
+	},
+	legionnaire: {
+		label: 'Legionnaire',
+		realmName: 'Legionnaire',
+		build: BUILD_12340,
+		realmlistType: 'trinitycore'
+	},
+	barracks: {
+		label: 'Barracks',
+		realmName: 'Barracks',
+		build: BUILD_12342,
+		realmlistType: 'trinitycore'
+	},
+	barracks_plus: {
+		label: 'Barracks+',
+		realmName: 'Barracks Plus',
+		build: BUILD_12342,
+		realmlistType: 'trinitycore'
+	},
+	trinityworld: {
+		label: 'TRINITYWORLD',
+		realmName: 'TRINITYWORLD',
+		build: BUILD_12340,
+		realmlistType: 'trinitycore'
+	},
+	townsendboys: {
+		label: 'TOWNSENDBOYS',
+		realmName: 'TOWNSENDBOYS',
+		build: BUILD_12340,
+		realmlistType: 'azerothcore'
+	}
 };
 
 export const FileMap: Record<
-        string,
-        {
-                extractPath: string;
-                optional?: true;
-                label?: string;
-                description?: string;
-                realms?: RealmId[];
-        }
+	string,
+	{
+		extractPath: string;
+		optional?: true;
+		label?: string;
+		description?: string;
+		realms?: RealmId[];
+	}
 > = {
-        ['addons']: { extractPath: 'Interface/Addons' },
-        ['patch-enUS-4']: { extractPath: 'Data/enUS', realms: ['townsendboys'] },
-        ['patch-enUS-6']: {
-                extractPath: 'Data/enUS',
-                realms: ['legionnaire', 'legionnaire_plus', 'barracks', 'barracks_plus']
-        },
-        ['patch-enUS-7']: {
-                extractPath: 'Data/enUS',
-                realms: ['legionnaire', 'legionnaire_plus', 'barracks', 'barracks_plus']
-        },
-        ['patch-enUS-8']: { extractPath: 'Data/enUS', realms: ['legionnaire_plus'] },
-        ['patch-enUS-9']: { extractPath: 'Data/enUS', realms: ['barracks'] },
-        ['patch-enUS-A']: { extractPath: 'Data/enUS', realms: ['barracks_plus'] },
-        ['patch-Z']: { extractPath: 'Data' },
-        ['patch-dungeon-maps']: { extractPath: 'Data', realms: ['barracks', 'townsendboys'] },
-        ['hd-creatures']: {
-                extractPath: 'Data',
-                optional: true,
-                label: 'HD Creatures',
-                description: 'Higher resolution retail creature models'
-        },
-        ['hd-textures']: {
-                extractPath: 'Data',
-                optional: true,
-                label: 'HD Textures',
-                description: 'Higher resolution retail textures'
-        },
-        ['hd-spells']: {
-                extractPath: 'Data',
-                optional: true,
-                label: 'HD Spells',
-                description: 'Higher resolution retail spell visuals'
-        },
-        ['hd-bgs']: {
-                extractPath: 'Data',
-                optional: true,
-                label: 'HD Battlegrounds',
-                description: 'Higher detail retail battleground maps'
-        },
-        ['hd-misc']: {
-                extractPath: 'Data',
-                optional: true,
-                label: 'HD Interface',
-                description: 'Shadowlands style user interface'
-        }
+	['addons']: { extractPath: 'Interface/Addons' },
+	['patch-enUS-4']: { extractPath: 'Data/enUS', realms: ['townsendboys'] },
+	['patch-enUS-6']: {
+		extractPath: 'Data/enUS',
+		realms: ['legionnaire', 'legionnaire_plus', 'barracks', 'barracks_plus']
+	},
+	['patch-enUS-7']: {
+		extractPath: 'Data/enUS',
+		realms: ['legionnaire', 'legionnaire_plus', 'barracks', 'barracks_plus']
+	},
+	['patch-enUS-8']: { extractPath: 'Data/enUS', realms: ['legionnaire_plus'] },
+	['patch-enUS-9']: { extractPath: 'Data/enUS', realms: ['barracks'] },
+	['patch-enUS-A']: { extractPath: 'Data/enUS', realms: ['barracks_plus'] },
+	['patch-Z']: { extractPath: 'Data' },
+	['patch-dungeon-maps']: {
+		extractPath: 'Data',
+		realms: ['barracks', 'townsendboys']
+	},
+	['hd-creatures']: {
+		extractPath: 'Data',
+		optional: true,
+		label: 'HD Creatures',
+		description: 'Higher resolution retail creature models'
+	},
+	['hd-textures']: {
+		extractPath: 'Data',
+		optional: true,
+		label: 'HD Textures',
+		description: 'Higher resolution retail textures'
+	},
+	['hd-spells']: {
+		extractPath: 'Data',
+		optional: true,
+		label: 'HD Spells',
+		description: 'Higher resolution retail spell visuals'
+	},
+	['hd-bgs']: {
+		extractPath: 'Data',
+		optional: true,
+		label: 'HD Battlegrounds',
+		description: 'Higher detail retail battleground maps'
+	},
+	['hd-misc']: {
+		extractPath: 'Data',
+		optional: true,
+		label: 'HD Interface',
+		description: 'Shadowlands style user interface'
+	}
 };

--- a/src/main/modules/preferences.ts
+++ b/src/main/modules/preferences.ts
@@ -4,75 +4,78 @@ import fs from 'fs-extra';
 import { app } from 'electron';
 
 import {
-        DEFAULT_AZEROTHCORE_REALMLIST,
-        DEFAULT_LAUNCHER_UPDATE_URL,
-        DEFAULT_REALMLIST
+	DEFAULT_AZEROTHCORE_REALMLIST,
+	DEFAULT_LAUNCHER_UPDATE_URL,
+	DEFAULT_REALMLIST,
+	PUBLIC_REALM_IDS
 } from '~common/constants';
 import {
-        PreferencesSchema,
-        type PreferencesSchema as PreferencesData
+	PreferencesSchema,
+	type PreferencesSchema as PreferencesData
 } from '~common/schemas';
 import { omit } from '~common/utils';
 
 const portableDir = process.env.PORTABLE_EXECUTABLE_DIR;
 
 const enforceRealmVisibility = (prefs: PreferencesData): PreferencesData =>
-        prefs.isDev ? prefs : { ...prefs, selectedRealm: 'legionnaire_plus' };
+	prefs.isDev || PUBLIC_REALM_IDS.includes(prefs.selectedRealm)
+		? prefs
+		: { ...prefs, selectedRealm: 'legionnaire_plus' };
 
 abstract class Preferences {
-        static #data: PreferencesData = enforceRealmVisibility(
-                PreferencesSchema.parse({
-                        launcherUpdateUrl: DEFAULT_LAUNCHER_UPDATE_URL,
-                        realmList: DEFAULT_REALMLIST,
-                        azerothcoreRealmList: DEFAULT_AZEROTHCORE_REALMLIST
-                })
-        );
+	static #data: PreferencesData = enforceRealmVisibility(
+		PreferencesSchema.parse({
+			launcherUpdateUrl: DEFAULT_LAUNCHER_UPDATE_URL,
+			realmList: DEFAULT_REALMLIST,
+			azerothcoreRealmList: DEFAULT_AZEROTHCORE_REALMLIST
+		})
+	);
 
-        static readonly userDataDir = process.env.PORTABLE_EXECUTABLE_DIR
-                ? path.join(process.env.PORTABLE_EXECUTABLE_DIR, '.launcher')
-                : app.getPath('userData');
+	static readonly userDataDir = process.env.PORTABLE_EXECUTABLE_DIR
+		? path.join(process.env.PORTABLE_EXECUTABLE_DIR, '.launcher')
+		: app.getPath('userData');
 
-        static async load() {
-                const userDataPath = path.join(this.userDataDir, 'settings.json');
-                try {
-                        const json = await fs.readJSON(userDataPath);
-                        return enforceRealmVisibility(
-                                PreferencesSchema.parse({
-                                        ...json,
-                                        isPortable: !!portableDir,
-                                        clientDir: portableDir ?? json.clientDir
-                                })
-                        );
-                } catch (e) {
-                        return enforceRealmVisibility(
-                                PreferencesSchema.parse({
-                                        isPortable: !!portableDir,
-                                        clientDir: portableDir
-                                })
-                        );
-                }
-        }
+	static async load() {
+		const userDataPath = path.join(this.userDataDir, 'settings.json');
+		try {
+			const json = await fs.readJSON(userDataPath);
+			return enforceRealmVisibility(
+				PreferencesSchema.parse({
+					...json,
+					isPortable: !!portableDir,
+					clientDir: portableDir ?? json.clientDir
+				})
+			);
+		} catch (e) {
+			return enforceRealmVisibility(
+				PreferencesSchema.parse({
+					isPortable: !!portableDir,
+					clientDir: portableDir
+				})
+			);
+		}
+	}
 
-        static get data(): PreferencesData {
-                return this.#data;
-        }
+	static get data(): PreferencesData {
+		return this.#data;
+	}
 
-        static set data(newData: Partial<Omit<PreferencesData, 'portableDir'>>) {
-                const parsed = PreferencesSchema.parse({ ...this.#data, ...newData });
-                this.#data = enforceRealmVisibility(parsed);
-                void fs.writeJSON(
-                        path.join(this.userDataDir, 'settings.json'),
-                        omit(
-                                this.#data,
-                                portableDir ? ['isPortable', 'clientDir'] : ['isPortable']
-                        ),
-                        { spaces: 2 }
-                );
-        }
+	static set data(newData: Partial<Omit<PreferencesData, 'portableDir'>>) {
+		const parsed = PreferencesSchema.parse({ ...this.#data, ...newData });
+		this.#data = enforceRealmVisibility(parsed);
+		void fs.writeJSON(
+			path.join(this.userDataDir, 'settings.json'),
+			omit(
+				this.#data,
+				portableDir ? ['isPortable', 'clientDir'] : ['isPortable']
+			),
+			{ spaces: 2 }
+		);
+	}
 
-        static async isValidClientDir(clientDir?: string) {
-                return !!clientDir && (await fs.exists(path.join(clientDir, 'WoW.exe')));
-        }
+	static async isValidClientDir(clientDir?: string) {
+		return !!clientDir && (await fs.exists(path.join(clientDir, 'WoW.exe')));
+	}
 }
 
 export default Preferences;

--- a/src/renderer/components/RealmSwitch.tsx
+++ b/src/renderer/components/RealmSwitch.tsx
@@ -1,68 +1,69 @@
 import { useState } from 'react';
 
-import { REALMS, type RealmId } from '~common/constants';
+import { PUBLIC_REALM_IDS, REALMS, type RealmId } from '~common/constants';
 import { type UpdaterStatus } from '~main/types';
 import { api } from '~renderer/utils/api';
 
 const RealmSwitch = () => {
-        const { data: pref } = api.preferences.get.useQuery();
-        const setPref = api.preferences.set.useMutation();
+	const { data: pref } = api.preferences.get.useQuery();
+	const setPref = api.preferences.set.useMutation();
 
-        const invalidate = api.updater.invalidate.useMutation();
-        const verify = api.updater.verify.useMutation();
+	const invalidate = api.updater.invalidate.useMutation();
+	const verify = api.updater.verify.useMutation();
 
-        const [updaterState, setUpdaterState] = useState<UpdaterStatus['state']>('needsValidation');
-        api.updater.observe.useSubscription(undefined, {
-                onData: data => setUpdaterState(data.state)
-        });
+	const [updaterState, setUpdaterState] =
+		useState<UpdaterStatus['state']>('needsValidation');
+	api.updater.observe.useSubscription(undefined, {
+		onData: data => setUpdaterState(data.state)
+	});
 
-        const isUpdaterBusy = updaterState === 'verifying' || updaterState === 'updating';
-        const isMutating = setPref.isLoading || invalidate.isLoading || verify.isLoading;
-        const isLoading = isUpdaterBusy || isMutating;
+	const isUpdaterBusy =
+		updaterState === 'verifying' || updaterState === 'updating';
+	const isMutating =
+		setPref.isLoading || invalidate.isLoading || verify.isLoading;
+	const isLoading = isUpdaterBusy || isMutating;
 
-        const onSelect = async (realm: RealmId) => {
-                if (isLoading) return;
-                if (pref?.selectedRealm === realm) return;
-                await setPref.mutateAsync({ selectedRealm: realm });
-                await invalidate.mutateAsync();
-                await verify.mutateAsync();
-        };
+	const onSelect = async (realm: RealmId) => {
+		if (isLoading) return;
+		if (pref?.selectedRealm === realm) return;
+		await setPref.mutateAsync({ selectedRealm: realm });
+		await invalidate.mutateAsync();
+		await verify.mutateAsync();
+	};
 
-        const availableRealmEntries: [RealmId, (typeof REALMS)[RealmId]][] = pref?.isDev
-                ? (Object.entries(REALMS) as [RealmId, (typeof REALMS)[RealmId]][])
-                : [
-                          ['legionnaire_plus', REALMS.legionnaire_plus],
-                          ['barracks_plus', REALMS.barracks_plus]
-                  ];
+	const availableRealmEntries: [RealmId, (typeof REALMS)[RealmId]][] =
+		pref?.isDev
+			? (Object.entries(REALMS) as [RealmId, (typeof REALMS)[RealmId]][])
+			: PUBLIC_REALM_IDS.map(id => [id, REALMS[id]]);
 
-        const selectedRealm =
-                pref?.selectedRealm &&
-                availableRealmEntries.some(([id]) => id === pref.selectedRealm)
-                        ? pref.selectedRealm
-                        : 'legionnaire_plus';
+	const selectedRealm =
+		pref?.selectedRealm &&
+		availableRealmEntries.some(([id]) => id === pref.selectedRealm)
+			? pref.selectedRealm
+			: 'legionnaire_plus';
 
-        return (
-                <>
-                        <p className="text-2xl">Select server:</p>
-                        <div className="flex">
-                                <select
-                                        className="w-full rounded border border-dark bg-dark p-3 text-lg uppercase text-text"
-                                        value={selectedRealm}
-                                        onChange={event => onSelect(event.target.value as RealmId)}
-                                        disabled={isLoading}
-                                >
-                                        <option value="" disabled hidden>
-                                                Select a realm
-                                        </option>
-                                        {availableRealmEntries.map(([id, meta]) => (
-                                                <option key={id} value={id}>
-                                                        {meta.label}
-                                                </option>
-                                        ))}
-                                </select>
-                        </div>
-                </>
-        );
+	return (
+		<>
+			<p className="text-2xl">Select server:</p>
+			<div className="flex">
+				<select
+					className="w-full rounded border border-dark bg-dark p-3 text-lg uppercase text-text"
+					value={selectedRealm}
+					onChange={event => onSelect(event.target.value as RealmId)}
+					disabled={isLoading}
+				>
+					<option value="" disabled hidden>
+						Select a realm
+					</option>
+					{availableRealmEntries.map(([id, meta]) => (
+						<option key={id} value={id}>
+							{meta.label}
+						</option>
+					))}
+				</select>
+			</div>
+		</>
+	);
 };
 
 export default RealmSwitch;


### PR DESCRIPTION
### Motivation
- Users reported that choosing `barracks_plus` (Barracks+) while `isDev` is `false` caused the selected realm to be reset to `legionnaire_plus`, so the change preserves legitimate public realm selections for non-dev users.

### Description
- Add a shared `PUBLIC_REALM_IDS` array containing the public realms (`'legionnaire_plus'`, `'barracks_plus'`) in `src/common/constants.ts` to centralize the allowlist.
- Update `enforceRealmVisibility` in `src/main/modules/preferences.ts` to keep the user's `selectedRealm` when `prefs.isDev` is true or when `selectedRealm` is included in `PUBLIC_REALM_IDS` instead of always forcing `legionnaire_plus`.
- Change the realm switch UI in `src/renderer/components/RealmSwitch.tsx` to use `PUBLIC_REALM_IDS` for the non-dev dropdown entries so UI availability matches preference validation.
- Reformatted affected files with `prettier` as part of the edits.

### Testing
- Ran `npx prettier --write src/common/constants.ts src/main/modules/preferences.ts src/renderer/components/RealmSwitch.tsx`, which completed successfully.
- Ran the build for the test mode with `npm run build:test`, which completed successfully (renderer and main bundles built).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e2f04a7b8832792f50f5534a2f536)