### PR TITLE
Update default server endpoints

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,6 +1,6 @@
-export const DEFAULT_LAUNCHER_UPDATE_URL = 'http://136.56.187.218/downloads/';
-export const DEFAULT_REALMLIST = '136.56.187.218';
-export const DEFAULT_AZEROTHCORE_REALMLIST = '136.56.187.218:3726';
+export const DEFAULT_LAUNCHER_UPDATE_URL = 'http://centurionpvp.com/downloads/';
+export const DEFAULT_REALMLIST = 'centurionpvp.com';
+export const DEFAULT_AZEROTHCORE_REALMLIST = 'centurionpvp.com:3726';
 
 export const REALM_IDS = [
 	'legionnaire_plus',


### PR DESCRIPTION
### Motivation
- Align the launcher's built-in default endpoints with the public Centurion domain instead of the previous IP address.
- Ensure default values used across preferences, updater and patcher modules point to the correct host for downloads and realmlist lookups.

### Description
- Changed `DEFAULT_LAUNCHER_UPDATE_URL` in `src/common/constants.ts` from `http://136.56.187.218/downloads/` to `http://centurionpvp.com/downloads/`.
- Changed `DEFAULT_REALMLIST` in `src/common/constants.ts` from `136.56.187.218` to `centurionpvp.com`.
- Changed `DEFAULT_AZEROTHCORE_REALMLIST` in `src/common/constants.ts` from `136.56.187.218:3726` to `centurionpvp.com:3726`.
- These defaults are consumed by preferences, the updater and the patcher modules to determine update and realmlist targets.

### Testing
- Ran `npm run build` which completed successfully and produced the renderer and main bundles without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a507ab8d80483279f93c06b6a3373d4)